### PR TITLE
feat: スクロールリビール & ノイズテクスチャ

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,21 +115,27 @@
   }
 }
 
-/* Scroll reveal animation */
-.reveal {
-  opacity: 0;
-  transform: translateY(20px);
-  transition:
-    opacity 0.6s ease,
-    transform 0.6s ease;
-}
+@layer utilities {
+  .reveal {
+    opacity: 0;
+    transform: translateY(20px);
+    transition:
+      opacity 0.6s ease,
+      transform 0.6s ease;
+  }
 
-.reveal.visible {
-  opacity: 1;
-  transform: translateY(0);
+  .reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .reveal {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
   *,
   *::before,
   *::after {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -115,6 +115,20 @@
   }
 }
 
+/* Scroll reveal animation */
+.reveal {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 0.6s ease,
+    transform 0.6s ease;
+}
+
+.reveal.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Footer } from '@/components/footer';
 import { Header } from '@/components/header';
+import { NoiseOverlay } from '@/components/noise-overlay';
 import { ThemeProvider } from '@/components/theme-provider';
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono, Noto_Sans_JP } from 'next/font/google';
@@ -61,6 +62,7 @@ export default function RootLayout({
           <Header />
           <main id="main-content">{children}</main>
           <Footer />
+          <NoiseOverlay />
         </ThemeProvider>
       </body>
     </html>

--- a/src/components/noise-overlay.stories.tsx
+++ b/src/components/noise-overlay.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { NoiseOverlay } from './noise-overlay';
+import { ThemeProvider } from './theme-provider';
+
+const meta = {
+  title: 'Components/NoiseOverlay',
+  component: NoiseOverlay,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'SVG fractalNoise による grain テクスチャオーバーレイ。opacity 1.8%, mix-blend-mode overlay。',
+      },
+    },
+  },
+} satisfies Meta<typeof NoiseOverlay>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+      <div className="relative min-h-[50vh] bg-background p-8">
+        <NoiseOverlay />
+        <h2 className="mb-4 text-2xl font-bold">Noise Overlay Demo</h2>
+        <p className="text-muted-foreground">
+          微細な grain テクスチャが画面全体に適用されています（opacity 1.8%）。
+        </p>
+        <div className="mt-8 grid grid-cols-2 gap-4">
+          <div className="rounded-lg bg-primary p-8 text-primary-foreground">Primary</div>
+          <div className="rounded-lg bg-secondary p-8 text-secondary-foreground">Secondary</div>
+        </div>
+      </div>
+    </ThemeProvider>
+  ),
+};
+
+export const DarkMode: Story = {
+  globals: { theme: 'dark' },
+  render: () => (
+    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
+      <div className="relative min-h-[50vh] bg-background p-8">
+        <NoiseOverlay />
+        <h2 className="mb-4 text-2xl font-bold">Noise Overlay (Dark)</h2>
+        <p className="text-muted-foreground">
+          ダークモードでも同じ grain テクスチャが適用されます。
+        </p>
+        <div className="mt-8 grid grid-cols-2 gap-4">
+          <div className="rounded-lg bg-primary p-8 text-primary-foreground">Primary</div>
+          <div className="rounded-lg bg-secondary p-8 text-secondary-foreground">Secondary</div>
+        </div>
+      </div>
+    </ThemeProvider>
+  ),
+};

--- a/src/components/noise-overlay.tsx
+++ b/src/components/noise-overlay.tsx
@@ -1,0 +1,13 @@
+export function NoiseOverlay() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-[9999] opacity-[0.018] mix-blend-overlay"
+      style={{
+        backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
+        backgroundRepeat: 'repeat',
+        backgroundSize: '256px 256px',
+      }}
+    />
+  );
+}

--- a/src/components/scroll-reveal.stories.tsx
+++ b/src/components/scroll-reveal.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ScrollReveal } from './scroll-reveal';
+import { ThemeProvider } from './theme-provider';
+
+const meta = {
+  title: 'Components/ScrollReveal',
+  component: ScrollReveal,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'IntersectionObserver による scroll reveal アニメーション。要素がビューポートに入ると fadeUp で表示。prefers-reduced-motion 対応。',
+      },
+    },
+  },
+} satisfies Meta<typeof ScrollReveal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: null,
+  },
+  render: () => (
+    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
+      <div className="p-8">
+        <p className="mb-8 text-muted-foreground">下にスクロールしてください</p>
+        <div className="h-[80vh]" />
+        {[1, 2, 3].map((i) => (
+          <ScrollReveal key={i} className="mb-8">
+            <div className="rounded-lg border border-border bg-card p-8">
+              <h3 className="mb-2 text-lg font-bold">セクション {i}</h3>
+              <p className="text-muted-foreground">このカードはスクロールで表示されます。</p>
+            </div>
+          </ScrollReveal>
+        ))}
+      </div>
+    </ThemeProvider>
+  ),
+};

--- a/src/components/scroll-reveal.tsx
+++ b/src/components/scroll-reveal.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useScrollReveal } from '@/hooks/use-scroll-reveal';
+import { cn } from '@/lib/utils';
+
+interface ScrollRevealProps {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+  readonly as?: 'div' | 'section';
+  readonly threshold?: number;
+}
+
+export function ScrollReveal({
+  children,
+  className,
+  as: Tag = 'div',
+  threshold,
+}: ScrollRevealProps) {
+  const ref = useScrollReveal<HTMLElement>({ threshold });
+
+  return (
+    <Tag
+      ref={ref as React.Ref<HTMLDivElement> & React.Ref<HTMLElement>}
+      className={cn('reveal', className)}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/src/components/scroll-reveal.tsx
+++ b/src/components/scroll-reveal.tsx
@@ -16,10 +16,10 @@ export function ScrollReveal({
   as: Tag = 'div',
   threshold,
 }: ScrollRevealProps) {
-  const ref = useScrollReveal<HTMLElement>({ threshold });
+  const ref = useScrollReveal<HTMLDivElement>({ threshold });
 
   return (
-    <Tag ref={ref as React.RefObject<HTMLDivElement>} className={cn('reveal', className)}>
+    <Tag ref={ref} className={cn('reveal', className)}>
       {children}
     </Tag>
   );

--- a/src/components/scroll-reveal.tsx
+++ b/src/components/scroll-reveal.tsx
@@ -16,13 +16,10 @@ export function ScrollReveal({
   as: Tag = 'div',
   threshold,
 }: ScrollRevealProps) {
-  const ref = useScrollReveal<HTMLElement>({ threshold });
+  const ref = useScrollReveal<HTMLDivElement>({ threshold });
 
   return (
-    <Tag
-      ref={ref as React.Ref<HTMLDivElement> & React.Ref<HTMLElement>}
-      className={cn('reveal', className)}
-    >
+    <Tag ref={ref} className={cn('reveal', className)}>
       {children}
     </Tag>
   );

--- a/src/components/scroll-reveal.tsx
+++ b/src/components/scroll-reveal.tsx
@@ -16,10 +16,10 @@ export function ScrollReveal({
   as: Tag = 'div',
   threshold,
 }: ScrollRevealProps) {
-  const ref = useScrollReveal<HTMLDivElement>({ threshold });
+  const ref = useScrollReveal<HTMLElement>({ threshold });
 
   return (
-    <Tag ref={ref} className={cn('reveal', className)}>
+    <Tag ref={ref as React.RefObject<HTMLDivElement>} className={cn('reveal', className)}>
       {children}
     </Tag>
   );

--- a/src/hooks/use-scroll-reveal.ts
+++ b/src/hooks/use-scroll-reveal.ts
@@ -37,6 +37,8 @@ export function useScrollReveal<T extends HTMLElement>({
           if (entry.isIntersecting) {
             entry.target.classList.add('visible');
             if (once) observer.unobserve(entry.target);
+          } else if (!once) {
+            entry.target.classList.remove('visible');
           }
         }
       },

--- a/src/hooks/use-scroll-reveal.ts
+++ b/src/hooks/use-scroll-reveal.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface UseScrollRevealOptions {
+  readonly threshold?: number;
+  readonly once?: boolean;
+}
+
+export function useScrollReveal<T extends HTMLElement>({
+  threshold = 0.1,
+  once = true,
+}: UseScrollRevealOptions = {}) {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      el.classList.add('visible');
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            if (once) observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold },
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold, once]);
+
+  return ref;
+}

--- a/src/hooks/use-scroll-reveal.ts
+++ b/src/hooks/use-scroll-reveal.ts
@@ -7,6 +7,10 @@ interface UseScrollRevealOptions {
   readonly once?: boolean;
 }
 
+/**
+ * IntersectionObserver で要素の可視性を検出し、.visible クラスを付与する。
+ * DOM classList を直接操作する（CSS 駆動アニメーションのため React state 不使用）。
+ */
 export function useScrollReveal<T extends HTMLElement>({
   threshold = 0.1,
   once = true,
@@ -16,6 +20,11 @@ export function useScrollReveal<T extends HTMLElement>({
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+
+    if (typeof IntersectionObserver === 'undefined') {
+      el.classList.add('visible');
+      return;
+    }
 
     if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
       el.classList.add('visible');
@@ -35,7 +44,7 @@ export function useScrollReveal<T extends HTMLElement>({
     );
 
     observer.observe(el);
-    return () => observer.disconnect();
+    return () => observer.unobserve(el);
   }, [threshold, once]);
 
   return ref;


### PR DESCRIPTION
## Summary
- **ScrollReveal**: IntersectionObserver で要素がビューポートに入ると fadeUp (opacity 0→1, translateY 20px→0, 0.6s ease) で表示
- **NoiseOverlay**: SVG fractalNoise による grain テクスチャ (opacity 1.8%, mix-blend-mode overlay, z-9999)
- **useScrollReveal hook**: 再利用可能な IntersectionObserver hook (threshold/once オプション)
- `prefers-reduced-motion` 対応: アニメーション無効化 + 即時表示

## Changes
| File | Description |
|------|-------------|
| `src/hooks/use-scroll-reveal.ts` | 新規: useScrollReveal hook |
| `src/components/scroll-reveal.tsx` | 新規: ScrollReveal コンポーネント (.reveal → .visible) |
| `src/components/scroll-reveal.stories.tsx` | 新規: スクロールデモ Story |
| `src/components/noise-overlay.tsx` | 新規: NoiseOverlay (SVG fractalNoise) |
| `src/components/noise-overlay.stories.tsx` | 新規: Light / Dark デモ Story |
| `src/app/globals.css` | `.reveal` / `.visible` CSS クラス追加 |
| `src/app/layout.tsx` | `<NoiseOverlay />` を ThemeProvider 内に配置 |

## Design Decisions
- **CSS クラス (.reveal/.visible)**: Tailwind の `group/group-hover` では IntersectionObserver 連動が困難。CSS クラストグルが最適
- **`prefers-reduced-motion`**: hook 内で `matchMedia` チェック → 即座に `.visible` を付与してアニメーションスキップ。globals.css の `transition-duration: 0.01ms` と合わせて二重保護
- **NoiseOverlay**: `position: fixed` + `pointer-events: none` でインタラクションに影響なし。`aria-hidden="true"` で a11y 対応

## Test plan
- [x] `bun build` 成功
- [x] `bun storybook` で ScrollReveal Story: スクロールで fadeUp 動作確認
- [x] `bun storybook` で NoiseOverlay Story: grain テクスチャ表示確認
- [x] OS の reduce-motion 設定 ON → アニメーションなしで即時表示

Closes #23