### PR TITLE
feat: Epic #2 最終チェック — デザイン調整 & 全 Story 検証

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Productivity Engineer "Rym" のポートフォリオ & 技術ブログ。Site: R
 
 ### Colors (CSS Variables)
 **Light** — bg: #fafafa / card: #fff / accent: #0c6b58 / accent-2: #14b890 / gradient: #084c3e→#14b890
-**Dark** — bg: #09090b / card: #1a1a1f / accent: #5cd8c8 (teal) / accent-2: #94ede0 / gradient: #0e8a7a→#5cd8c8
+**Dark** — bg: #09090b / card: #1a1a1f / accent: #5cd8c8 (teal) / accent-2: #94ede0 / gradient: #065a4e→#2db89a
 text-muted は WCAG AA 準拠。カラーは意図的に Tailwind プリセットからずらしている。
 
 ### Tags
@@ -94,8 +94,8 @@ Epics #1-#10 (`epic`), Tasks #11-#44 (`task`)
 
 ## Storybook Story ルール
 - **データはモック準拠**: Story のサンプルデータ（タイトル、説明、日付等）は `design-mock/design-mockup-v11.html` からコピーする。適当なプレースホルダーを使わない
-- **ThemeProvider は最小限**: `useTheme()` を使うコンポーネント (ThemeToggle, Header) のみ ThemeProvider でラップ。他は `preview.tsx` の `WithThemeClass` デコレータ + `globals: { theme: 'dark' }` でテーマ制御
-- **DarkMode Story**: `globals: { theme: 'dark' }` を必ず設定
+- **ThemeProvider は最小限**: `useTheme()` を直接/間接的に使用するコンポーネント (ThemeToggle, および ThemeToggle を内包する Header) のみ ThemeProvider でラップ。他は `preview.tsx` の `WithThemeClass` デコレータ + `globals: { theme: 'dark' }` でテーマ制御
+- **DarkMode Story**: 全コンポーネントに DarkMode variant を用意し、`globals: { theme: 'dark' }` を必ず設定する
 - **モック変更時は双方更新**: 実装の CSS 変数やスタイルを変更したら、モック HTML も同時に更新する
 - Geist: next/font/google (Next.js 16 で Google Fonts 対応済, モックは CDN 代用)
 - モック確認: `python3 -m http.server 8234` → localhost:8234/design-mock/design-mockup-v11.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,14 @@ Epics #1-#10 (`epic`), Tasks #11-#44 (`task`)
 ## Implementation Notes
 - 実装順: セットアップ (#11-#16,#42) → Story 先行 → コンポーネント → ページ組み立て
 - Storybook: @storybook/nextjs-vite v10.3.x (Next.js 16 対応済), Tailwind v4 は @tailwindcss/vite で統合
-- Iconify: 実装時は @iconify/json でバンドル (CDN は FOUC リスク)
+- lefthook: pre-commit で `format:check` + `lint` を自動実行
+- Iconify: 実装時は @iconify/json でバンドル (CDN は FOUC リスク)。現状は lucide-react + インライン SVG (social icons) で統一
+
+## Storybook Story ルール
+- **データはモック準拠**: Story のサンプルデータ（タイトル、説明、日付等）は `design-mock/design-mockup-v11.html` からコピーする。適当なプレースホルダーを使わない
+- **ThemeProvider は最小限**: `useTheme()` を使うコンポーネント (ThemeToggle, Header) のみ ThemeProvider でラップ。他は `preview.tsx` の `WithThemeClass` デコレータ + `globals: { theme: 'dark' }` でテーマ制御
+- **DarkMode Story**: `globals: { theme: 'dark' }` を必ず設定
+- **モック変更時は双方更新**: 実装の CSS 変数やスタイルを変更したら、モック HTML も同時に更新する
 - Geist: next/font/google (Next.js 16 で Google Fonts 対応済, モックは CDN 代用)
 - モック確認: `python3 -m http.server 8234` → localhost:8234/design-mock/design-mockup-v11.html
 

--- a/design-mock/design-mockup-v11.html
+++ b/design-mock/design-mockup-v11.html
@@ -56,7 +56,7 @@
     --accent: #5cd8c8;
     --accent-2: #94ede0;
     --accent-glow: rgba(92, 216, 200, 0.09);
-    --accent-gradient: linear-gradient(135deg, #0e8a7a, #5cd8c8);
+    --accent-gradient: linear-gradient(135deg, #065a4e, #2db89a);
     --hero-bg: linear-gradient(180deg, #0b0d0c 0%, #09090b 100%);
     --card-shadow: 0 1px 3px rgba(0,0,0,0.5);
     --card-shadow-hover: 0 8px 24px rgba(92,216,200,0.08), 0 2px 6px rgba(0,0,0,0.3);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -97,6 +97,7 @@
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
+  --color-text-secondary: var(--text-secondary);
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -67,7 +67,7 @@
     --bg-code: #222228;
     --accent-2: #94ede0;
     --accent-glow: rgba(92, 216, 200, 0.09);
-    --accent-gradient: linear-gradient(135deg, #0e8a7a, #5cd8c8);
+    --accent-gradient: linear-gradient(135deg, #065a4e, #2db89a);
     --hero-bg: linear-gradient(180deg, #0b0d0c 0%, #09090b 100%);
     --card-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
     --card-shadow-hover: 0 8px 24px rgba(92, 216, 200, 0.08), 0 2px 6px rgba(0, 0, 0, 0.3);

--- a/src/components/action-button.stories.tsx
+++ b/src/components/action-button.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { ActionButton } from './action-button';
-import { ThemeProvider } from './theme-provider';
 
 const meta = {
   title: 'Components/ActionButton',
@@ -27,11 +26,9 @@ export const Primary: Story = {
   },
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <div className="p-8">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="p-8">
+        <Story />
+      </div>
     ),
   ],
 };
@@ -44,11 +41,9 @@ export const Secondary: Story = {
   },
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <div className="p-8">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="p-8">
+        <Story />
+      </div>
     ),
   ],
 };
@@ -56,16 +51,14 @@ export const Secondary: Story = {
 export const ButtonGroup: Story = {
   args: { href: '/projects', children: 'Projects →' },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="flex gap-3 p-8">
-        <ActionButton href="/projects" variant="primary">
-          Projects →
-        </ActionButton>
-        <ActionButton href="/articles" variant="secondary">
-          Articles
-        </ActionButton>
-      </div>
-    </ThemeProvider>
+    <div className="flex gap-3 p-8">
+      <ActionButton href="/projects" variant="primary">
+        Projects →
+      </ActionButton>
+      <ActionButton href="/articles" variant="secondary">
+        Articles
+      </ActionButton>
+    </div>
   ),
 };
 
@@ -73,15 +66,13 @@ export const DarkMode: Story = {
   args: { href: '/projects', children: 'Projects →' },
   globals: { theme: 'dark' },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      <div className="flex gap-3 rounded-lg bg-background p-8">
-        <ActionButton href="/projects" variant="primary">
-          Projects →
-        </ActionButton>
-        <ActionButton href="/articles" variant="secondary">
-          Articles
-        </ActionButton>
-      </div>
-    </ThemeProvider>
+    <div className="flex gap-3 rounded-lg bg-background p-8">
+      <ActionButton href="/projects" variant="primary">
+        Projects →
+      </ActionButton>
+      <ActionButton href="/articles" variant="secondary">
+        Articles
+      </ActionButton>
+    </div>
   ),
 };

--- a/src/components/article-card.stories.tsx
+++ b/src/components/article-card.stories.tsx
@@ -5,6 +5,7 @@ import {
   BotIcon,
   GaugeIcon,
   GitBranchIcon,
+  InfinityIcon,
   SparklesIcon,
   UsersIcon,
   ZapIcon,
@@ -50,7 +51,7 @@ const sampleArticles: Article[] = [
     thumbnailVariant: 'v3',
     tags: [
       { label: 'Metrics', category: 'performance', icon: BarChart3Icon },
-      { label: 'DevOps', category: 'infra', icon: GitBranchIcon },
+      { label: 'DevOps', category: 'infra', icon: InfinityIcon },
     ],
   },
 ];

--- a/src/components/article-card.stories.tsx
+++ b/src/components/article-card.stories.tsx
@@ -1,47 +1,57 @@
 import type { Article } from '@/types/article';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { CloudIcon, CodeIcon, MonitorIcon, WrenchIcon, ZapIcon } from 'lucide-react';
+import {
+  BarChart3Icon,
+  BotIcon,
+  GaugeIcon,
+  GitBranchIcon,
+  SparklesIcon,
+  UsersIcon,
+  ZapIcon,
+} from 'lucide-react';
 import { ArticleCard } from './article-card';
 import { ThemeProvider } from './theme-provider';
 
 const sampleArticle: Article = {
-  slug: 'nextjs-cache-strategy',
-  title: 'Next.js 16 の use cache ディレクティブで ISR を超える',
+  slug: 'github-actions-cache',
+  title: 'GitHub Actions のキャッシュ戦略を徹底的に最適化する',
   publishedAt: '2026-03-15',
   updatedAt: '2026-03-20',
   readingTime: '8 min',
   thumbnailIcon: ZapIcon,
   thumbnailVariant: 'v1',
   tags: [
-    { label: 'Next.js', category: 'frontend', icon: MonitorIcon },
-    { label: 'TypeScript', category: 'languages', icon: CodeIcon },
+    { label: 'CI/CD', category: 'infra', icon: GitBranchIcon },
+    { label: 'Performance', category: 'performance', icon: GaugeIcon },
   ],
 };
 
 const sampleArticles: Article[] = [
   sampleArticle,
   {
-    slug: 'tailwind-v4-migration',
-    title: 'Tailwind CSS v4 移行ガイド — @theme inline と CSS-first 設定',
-    publishedAt: '2026-03-10',
+    slug: 'developer-onboarding',
+    title: '開発者オンボーディングを自動化して定着率を改善した話',
+    publishedAt: '2026-03-01',
+    updatedAt: '2026-03-05',
     readingTime: '12 min',
-    thumbnailIcon: WrenchIcon,
+    thumbnailIcon: UsersIcon,
     thumbnailVariant: 'v2',
     tags: [
-      { label: 'Tailwind', category: 'tools', icon: WrenchIcon },
-      { label: 'CSS', category: 'frontend', icon: MonitorIcon },
+      { label: 'DevEx', category: 'tools', icon: SparklesIcon },
+      { label: 'Automation', category: 'infra', icon: BotIcon },
     ],
   },
   {
-    slug: 'aws-ecs-deploy',
-    title: 'ECS Fargate で Next.js をゼロダウンタイムデプロイする',
-    publishedAt: '2026-02-28',
-    readingTime: '15 min',
-    thumbnailIcon: CloudIcon,
+    slug: 'dora-metrics',
+    title: 'DORA メトリクスを導入して開発チームの健全性を可視化する',
+    publishedAt: '2026-02-18',
+    updatedAt: '2026-02-22',
+    readingTime: '10 min',
+    thumbnailIcon: BarChart3Icon,
     thumbnailVariant: 'v3',
     tags: [
-      { label: 'AWS', category: 'infra', icon: CloudIcon },
-      { label: 'Docker', category: 'infra', icon: CloudIcon },
+      { label: 'Metrics', category: 'performance', icon: BarChart3Icon },
+      { label: 'DevOps', category: 'infra', icon: GitBranchIcon },
     ],
   },
 ];

--- a/src/components/article-card.stories.tsx
+++ b/src/components/article-card.stories.tsx
@@ -10,7 +10,6 @@ import {
   ZapIcon,
 } from 'lucide-react';
 import { ArticleCard } from './article-card';
-import { ThemeProvider } from './theme-provider';
 
 const sampleArticle: Article = {
   slug: 'github-actions-cache',
@@ -77,11 +76,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <div className="max-w-sm p-4">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="max-w-sm p-4">
+        <Story />
+      </div>
     ),
   ],
   args: {
@@ -92,13 +89,11 @@ export const Default: Story = {
 export const ThumbnailVariants: Story = {
   args: { article: sampleArticle },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5 p-4">
-        {sampleArticles.map((a) => (
-          <ArticleCard key={a.slug} article={a} />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5 p-4">
+      {sampleArticles.map((a) => (
+        <ArticleCard key={a.slug} article={a} />
+      ))}
+    </div>
   ),
 };
 
@@ -106,12 +101,10 @@ export const DarkMode: Story = {
   args: { article: sampleArticle },
   globals: { theme: 'dark' },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5 rounded-lg bg-background p-4">
-        {sampleArticles.map((a) => (
-          <ArticleCard key={a.slug} article={a} />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5 rounded-lg bg-background p-4">
+      {sampleArticles.map((a) => (
+        <ArticleCard key={a.slug} article={a} />
+      ))}
+    </div>
   ),
 };

--- a/src/components/footer.stories.tsx
+++ b/src/components/footer.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Footer } from './footer';
-import { ThemeProvider } from './theme-provider';
 
 const meta = {
   title: 'Components/Footer',
@@ -23,11 +22,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <div className="flex min-h-[50vh] flex-col justify-end">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="flex min-h-[50vh] flex-col justify-end">
+        <Story />
+      </div>
     ),
   ],
 };
@@ -36,11 +33,9 @@ export const DarkMode: Story = {
   globals: { theme: 'dark' },
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-        <div className="flex min-h-[50vh] flex-col justify-end">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="flex min-h-[50vh] flex-col justify-end">
+        <Story />
+      </div>
     ),
   ],
 };

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -87,7 +87,7 @@ export function Header() {
                           'block border-b border-border px-0 py-2.5 text-[15px] font-medium transition-colors duration-200 last:border-b-0',
                           isActive(pathname, href)
                             ? 'text-primary'
-                            : 'text-muted-foreground hover:text-primary',
+                            : 'text-text-secondary hover:text-primary',
                         )}
                       >
                         {label}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -26,13 +26,13 @@ export function Header() {
   const pathname = usePathname();
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-[16px] backdrop-saturate-[180%] transition-colors duration-300">
+    <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-lg backdrop-saturate-[180%] transition-colors duration-300">
       <div className="mx-auto flex h-15 max-w-[1200px] items-center justify-between px-4 md:px-6">
         {/* Logo */}
         <Link
           href="/"
           aria-label="Rymlab — ホームへ"
-          className="font-mono text-lg font-extrabold tracking-[-0.04em]"
+          className="font-mono text-lg font-extrabold tracking-tighter"
         >
           Rym<span className="text-primary">lab</span>
         </Link>
@@ -49,7 +49,7 @@ export function Header() {
                       'relative text-sm font-medium transition-colors duration-200',
                       isActive(pathname, href)
                         ? 'text-primary after:absolute after:-bottom-[19px] after:left-0 after:right-0 after:h-0.5 after:rounded-[1px] after:bg-[image:var(--accent-gradient)]'
-                        : 'text-muted-foreground hover:text-foreground',
+                        : 'text-text-secondary hover:text-foreground',
                     )}
                   >
                     {label}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -66,7 +66,12 @@ export function Header() {
             {/* Mobile Menu */}
             <Sheet key={pathname}>
               <SheetTrigger asChild>
-                <Button type="button" variant="outline" size="icon" className="md:hidden">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="md:hidden hover:bg-transparent hover:border-primary hover:text-primary"
+                >
                   <MenuIcon className="size-[18px]" />
                   <span className="sr-only">メニューを開く</span>
                 </Button>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -70,7 +70,7 @@ export function Header() {
                   type="button"
                   variant="outline"
                   size="icon"
-                  className="md:hidden hover:bg-transparent hover:border-primary hover:text-primary"
+                  className="md:hidden hover:bg-transparent dark:hover:bg-transparent hover:border-primary hover:text-primary"
                 >
                   <MenuIcon className="size-[18px]" />
                   <span className="sr-only">メニューを開く</span>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -26,13 +26,13 @@ export function Header() {
   const pathname = usePathname();
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-xl backdrop-saturate-[180%] transition-colors duration-300">
+    <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-[16px] backdrop-saturate-[180%] transition-colors duration-300">
       <div className="mx-auto flex h-15 max-w-[1200px] items-center justify-between px-4 md:px-6">
         {/* Logo */}
         <Link
           href="/"
           aria-label="Rymlab — ホームへ"
-          className="font-mono text-lg font-extrabold tracking-tighter"
+          className="font-mono text-lg font-extrabold tracking-[-0.04em]"
         >
           Rym<span className="text-primary">lab</span>
         </Link>

--- a/src/components/list-card.stories.tsx
+++ b/src/components/list-card.stories.tsx
@@ -1,6 +1,6 @@
 import type { Article } from '@/types/article';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { CodeIcon, GitBranchIcon, GitMergeIcon, RocketIcon } from 'lucide-react';
+import { CodeIcon, GitBranchIcon, GitMergeIcon, InfinityIcon, RocketIcon } from 'lucide-react';
 import { ListCard } from './list-card';
 
 const sampleArticles: Article[] = [
@@ -22,7 +22,7 @@ const sampleArticles: Article[] = [
     readingTime: '7 min',
     thumbnailIcon: RocketIcon,
     tags: [
-      { label: 'DevOps', category: 'infra', icon: GitBranchIcon },
+      { label: 'DevOps', category: 'infra', icon: InfinityIcon },
       { label: 'Release', category: 'release', icon: RocketIcon },
     ],
   },

--- a/src/components/list-card.stories.tsx
+++ b/src/components/list-card.stories.tsx
@@ -1,6 +1,6 @@
 import type { Article } from '@/types/article';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { CloudIcon, CodeIcon, GitMergeIcon, MonitorIcon } from 'lucide-react';
+import { CodeIcon, GitBranchIcon, GitMergeIcon, RocketIcon } from 'lucide-react';
 import { ListCard } from './list-card';
 import { ThemeProvider } from './theme-provider';
 
@@ -13,16 +13,19 @@ const sampleArticles: Article[] = [
     thumbnailIcon: GitMergeIcon,
     tags: [
       { label: 'TypeScript', category: 'languages', icon: CodeIcon },
-      { label: 'Infra', category: 'infra', icon: CloudIcon },
+      { label: 'CI/CD', category: 'infra', icon: GitBranchIcon },
     ],
   },
   {
-    slug: 'react-19-patterns',
-    title: 'React 19 の新パターンと Server Components 活用法',
-    publishedAt: '2026-02-10',
-    readingTime: '10 min',
-    thumbnailIcon: MonitorIcon,
-    tags: [{ label: 'React', category: 'frontend', icon: MonitorIcon }],
+    slug: 'feature-flags',
+    title: 'Feature Flags で安全にリリースする仕組みを構築する',
+    publishedAt: '2026-01-10',
+    readingTime: '7 min',
+    thumbnailIcon: RocketIcon,
+    tags: [
+      { label: 'DevOps', category: 'infra', icon: GitBranchIcon },
+      { label: 'Release', category: 'release', icon: RocketIcon },
+    ],
   },
 ];
 

--- a/src/components/list-card.stories.tsx
+++ b/src/components/list-card.stories.tsx
@@ -2,7 +2,6 @@ import type { Article } from '@/types/article';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { CodeIcon, GitBranchIcon, GitMergeIcon, RocketIcon } from 'lucide-react';
 import { ListCard } from './list-card';
-import { ThemeProvider } from './theme-provider';
 
 const sampleArticles: Article[] = [
   {
@@ -50,11 +49,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <div className="max-w-xl p-4">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="max-w-xl p-4">
+        <Story />
+      </div>
     ),
   ],
   args: {
@@ -65,13 +62,11 @@ export const Default: Story = {
 export const Stacked: Story = {
   args: { article: sampleArticles[0]! },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="flex max-w-xl flex-col gap-2.5 p-4">
-        {sampleArticles.map((a) => (
-          <ListCard key={a.slug} article={a} />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="flex max-w-xl flex-col gap-2.5 p-4">
+      {sampleArticles.map((a) => (
+        <ListCard key={a.slug} article={a} />
+      ))}
+    </div>
   ),
 };
 
@@ -79,12 +74,10 @@ export const DarkMode: Story = {
   args: { article: sampleArticles[0]! },
   globals: { theme: 'dark' },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      <div className="flex max-w-xl flex-col gap-2.5 rounded-lg bg-background p-4">
-        {sampleArticles.map((a) => (
-          <ListCard key={a.slug} article={a} />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="flex max-w-xl flex-col gap-2.5 rounded-lg bg-background p-4">
+      {sampleArticles.map((a) => (
+        <ListCard key={a.slug} article={a} />
+      ))}
+    </div>
   ),
 };

--- a/src/components/list-card.tsx
+++ b/src/components/list-card.tsx
@@ -14,7 +14,7 @@ function ListCardThumbnail({ icon: Icon }: { readonly icon: Article['thumbnailIc
   return (
     <div className="relative min-h-[90px] bg-secondary">
       {/* Gradient overlay */}
-      <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(8,76,62,0.06)_0%,rgba(20,184,144,0.06)_100%)] dark:bg-[linear-gradient(135deg,rgba(92,216,200,0.10)_0%,rgba(45,212,191,0.10)_100%)]" />
+      <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(4,120,87,0.06)_0%,rgba(5,150,105,0.06)_100%)] dark:bg-[linear-gradient(135deg,rgba(92,216,200,0.10)_0%,rgba(45,212,191,0.10)_100%)]" />
       {/* Grid pattern */}
       <div className="absolute inset-0 bg-[linear-gradient(rgba(0,0,0,0.02)_1px,transparent_1px),linear-gradient(90deg,rgba(0,0,0,0.02)_1px,transparent_1px)] bg-[size:14px_14px]" />
       {/* Icon */}

--- a/src/components/noise-overlay.stories.tsx
+++ b/src/components/noise-overlay.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { NoiseOverlay } from './noise-overlay';
-import { ThemeProvider } from './theme-provider';
 
 const meta = {
   title: 'Components/NoiseOverlay',
@@ -22,37 +21,31 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="relative min-h-[50vh] bg-background p-8">
-        <NoiseOverlay />
-        <h2 className="mb-4 text-2xl font-bold">Noise Overlay Demo</h2>
-        <p className="text-muted-foreground">
-          微細な grain テクスチャが画面全体に適用されています（opacity 1.8%）。
-        </p>
-        <div className="mt-8 grid grid-cols-2 gap-4">
-          <div className="rounded-lg bg-primary p-8 text-primary-foreground">Primary</div>
-          <div className="rounded-lg bg-secondary p-8 text-secondary-foreground">Secondary</div>
-        </div>
+    <div className="relative min-h-[50vh] bg-background p-8">
+      <NoiseOverlay />
+      <h2 className="mb-4 text-2xl font-bold">Noise Overlay Demo</h2>
+      <p className="text-muted-foreground">
+        微細な grain テクスチャが画面全体に適用されています（opacity 1.8%）。
+      </p>
+      <div className="mt-8 grid grid-cols-2 gap-4">
+        <div className="rounded-lg bg-primary p-8 text-primary-foreground">Primary</div>
+        <div className="rounded-lg bg-secondary p-8 text-secondary-foreground">Secondary</div>
       </div>
-    </ThemeProvider>
+    </div>
   ),
 };
 
 export const DarkMode: Story = {
   globals: { theme: 'dark' },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      <div className="relative min-h-[50vh] bg-background p-8">
-        <NoiseOverlay />
-        <h2 className="mb-4 text-2xl font-bold">Noise Overlay (Dark)</h2>
-        <p className="text-muted-foreground">
-          ダークモードでも同じ grain テクスチャが適用されます。
-        </p>
-        <div className="mt-8 grid grid-cols-2 gap-4">
-          <div className="rounded-lg bg-primary p-8 text-primary-foreground">Primary</div>
-          <div className="rounded-lg bg-secondary p-8 text-secondary-foreground">Secondary</div>
-        </div>
+    <div className="relative min-h-[50vh] bg-background p-8">
+      <NoiseOverlay />
+      <h2 className="mb-4 text-2xl font-bold">Noise Overlay (Dark)</h2>
+      <p className="text-muted-foreground">ダークモードでも同じ grain テクスチャが適用されます。</p>
+      <div className="mt-8 grid grid-cols-2 gap-4">
+        <div className="rounded-lg bg-primary p-8 text-primary-foreground">Primary</div>
+        <div className="rounded-lg bg-secondary p-8 text-secondary-foreground">Secondary</div>
       </div>
-    </ThemeProvider>
+    </div>
   ),
 };

--- a/src/components/noise-overlay.tsx
+++ b/src/components/noise-overlay.tsx
@@ -2,7 +2,7 @@ export function NoiseOverlay() {
   return (
     <div
       aria-hidden="true"
-      className="pointer-events-none fixed inset-0 z-[9999] opacity-[0.018] mix-blend-overlay"
+      className="pointer-events-none fixed inset-0 z-[9999] opacity-[0.018] mix-blend-overlay will-change-transform"
       style={{
         backgroundImage: `url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E")`,
         backgroundRepeat: 'repeat',

--- a/src/components/project-card.stories.tsx
+++ b/src/components/project-card.stories.tsx
@@ -4,6 +4,7 @@ import {
   BarChart3Icon,
   CloudIcon,
   CodeIcon,
+  ContainerIcon,
   LayoutDashboardIcon,
   MonitorIcon,
   ServerIcon,
@@ -21,7 +22,7 @@ const sampleProject: Project = {
   tags: [
     { label: 'GitHub Actions', category: 'infra', icon: CloudIcon },
     { label: 'TypeScript', category: 'languages', icon: CodeIcon },
-    { label: 'Docker', category: 'infra', icon: CloudIcon },
+    { label: 'Docker', category: 'infra', icon: ContainerIcon },
   ],
 };
 

--- a/src/components/project-card.stories.tsx
+++ b/src/components/project-card.stories.tsx
@@ -1,6 +1,14 @@
 import type { Project } from '@/types/project';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { CloudIcon, CodeIcon, MonitorIcon, ServerIcon, WrenchIcon, ZapIcon } from 'lucide-react';
+import {
+  BarChart3Icon,
+  CloudIcon,
+  CodeIcon,
+  LayoutDashboardIcon,
+  MonitorIcon,
+  ServerIcon,
+  ZapIcon,
+} from 'lucide-react';
 import { ProjectCard } from './project-card';
 import { ThemeProvider } from './theme-provider';
 
@@ -8,40 +16,42 @@ const sampleProject: Project = {
   slug: 'ci-cd-optimizer',
   title: 'CI/CD Pipeline Optimizer',
   description:
-    'GitHub Actions ワークフローの実行時間を 60% 短縮。キャッシュ戦略、並列実行、条件分岐の最適化を自動化するツール。',
+    'ビルド時間を70%短縮するCI/CDパイプライン最適化ツール。キャッシュ戦略と並列実行の自動チューニング。',
   role: 'Lead Engineer',
   icon: ZapIcon,
   tags: [
     { label: 'GitHub Actions', category: 'infra', icon: CloudIcon },
     { label: 'TypeScript', category: 'languages', icon: CodeIcon },
-    { label: 'Node.js', category: 'backend', icon: ServerIcon },
+    { label: 'Docker', category: 'infra', icon: CloudIcon },
   ],
 };
 
 const sampleProjects: Project[] = [
   sampleProject,
   {
-    slug: 'design-system',
-    title: 'Design System & Component Library',
+    slug: 'developer-portal',
+    title: 'Developer Portal',
     description:
-      'Storybook + Tailwind CSS による統一されたデザインシステム。コンポーネントカタログ、テーマ切替、アクセシビリティ対応。',
-    role: 'Frontend Architect',
-    icon: MonitorIcon,
+      '社内開発者ポータル。サービスカタログ、ドキュメント検索、オンボーディング自動化を統合。',
+    role: 'Platform Engineer',
+    icon: LayoutDashboardIcon,
     tags: [
-      { label: 'React', category: 'frontend', icon: MonitorIcon },
-      { label: 'Tailwind', category: 'tools', icon: WrenchIcon },
+      { label: 'Next.js', category: 'frontend', icon: MonitorIcon },
+      { label: 'Go', category: 'backend', icon: ServerIcon },
+      { label: 'Backstage', category: 'infra', icon: CloudIcon },
     ],
   },
   {
-    slug: 'api-gateway',
-    title: 'API Gateway Platform',
+    slug: 'devmetrics-dashboard',
+    title: 'DevMetrics Dashboard',
     description:
-      'マイクロサービス間のルーティング、認証、レート制限を一元管理。OpenAPI スキーマ駆動の自動バリデーション。',
-    role: 'Backend Engineer',
-    icon: ServerIcon,
+      'DORA メトリクス可視化ダッシュボード。デプロイ頻度、リードタイム、MTTR、変更失敗率を自動計測。',
+    role: 'OSS Author',
+    icon: BarChart3Icon,
     tags: [
-      { label: 'Go', category: 'languages', icon: CodeIcon },
-      { label: 'Docker', category: 'infra', icon: CloudIcon },
+      { label: 'React', category: 'frontend', icon: MonitorIcon },
+      { label: 'Python', category: 'languages', icon: CodeIcon },
+      { label: 'Grafana', category: 'performance', icon: BarChart3Icon },
     ],
   },
 ];
@@ -55,7 +65,7 @@ const meta = {
     docs: {
       description: {
         component:
-          'プロジェクトカード。アイコン + ロール + タイトル + 説明 + タグ。hover でグリーンバー + lift + 矢印表示。',
+          'プロジェクトカード。アイコン + ロール + タイトル + 説明 + タグ。hover でグリーンバー + lift + 矢印 + アイコン scale/rotate。',
       },
     },
   },

--- a/src/components/project-card.stories.tsx
+++ b/src/components/project-card.stories.tsx
@@ -10,7 +10,6 @@ import {
   ZapIcon,
 } from 'lucide-react';
 import { ProjectCard } from './project-card';
-import { ThemeProvider } from './theme-provider';
 
 const sampleProject: Project = {
   slug: 'ci-cd-optimizer',
@@ -77,11 +76,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <div className="max-w-sm p-4">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="max-w-sm p-4">
+        <Story />
+      </div>
     ),
   ],
   args: {
@@ -92,13 +89,11 @@ export const Default: Story = {
 export const Grid: Story = {
   args: { project: sampleProject },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5 p-4">
-        {sampleProjects.map((p) => (
-          <ProjectCard key={p.slug} project={p} />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5 p-4">
+      {sampleProjects.map((p) => (
+        <ProjectCard key={p.slug} project={p} />
+      ))}
+    </div>
   ),
 };
 
@@ -106,11 +101,9 @@ export const DarkMode: Story = {
   globals: { theme: 'dark' },
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-        <div className="max-w-sm rounded-lg bg-background p-4">
-          <Story />
-        </div>
-      </ThemeProvider>
+      <div className="max-w-sm rounded-lg bg-background p-4">
+        <Story />
+      </div>
     ),
   ],
   args: {

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -45,7 +45,7 @@ export function ProjectCard({ project, className }: ProjectCardProps) {
       </h3>
 
       {/* Description */}
-      <p className="mb-4 grow text-[13.5px] leading-relaxed text-muted-foreground">
+      <p className="mb-4 grow text-[13.5px] leading-relaxed text-text-secondary">
         {project.description}
       </p>
 

--- a/src/components/scroll-reveal.stories.tsx
+++ b/src/components/scroll-reveal.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { ScrollReveal } from './scroll-reveal';
-import { ThemeProvider } from './theme-provider';
 
 const meta = {
   title: 'Components/ScrollReveal',
@@ -25,19 +24,17 @@ export const Default: Story = {
     children: null,
   },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="p-8">
-        <p className="mb-8 text-muted-foreground">下にスクロールしてください</p>
-        <div className="h-[80vh]" />
-        {[1, 2, 3].map((i) => (
-          <ScrollReveal key={i} className="mb-8">
-            <div className="rounded-lg border border-border bg-card p-8">
-              <h3 className="mb-2 text-lg font-bold">セクション {i}</h3>
-              <p className="text-muted-foreground">このカードはスクロールで表示されます。</p>
-            </div>
-          </ScrollReveal>
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="p-8">
+      <p className="mb-8 text-muted-foreground">下にスクロールしてください</p>
+      <div className="h-[80vh]" />
+      {[1, 2, 3].map((i) => (
+        <ScrollReveal key={i} className="mb-8">
+          <div className="rounded-lg border border-border bg-card p-8">
+            <h3 className="mb-2 text-lg font-bold">セクション {i}</h3>
+            <p className="text-muted-foreground">このカードはスクロールで表示されます。</p>
+          </div>
+        </ScrollReveal>
+      ))}
+    </div>
   ),
 };

--- a/src/components/scroll-reveal.stories.tsx
+++ b/src/components/scroll-reveal.stories.tsx
@@ -38,3 +38,24 @@ export const Default: Story = {
     </div>
   ),
 };
+
+export const DarkMode: Story = {
+  args: {
+    children: null,
+  },
+  globals: { theme: 'dark' },
+  render: () => (
+    <div className="p-8">
+      <p className="mb-8 text-muted-foreground">下にスクロールしてください</p>
+      <div className="h-[80vh]" />
+      {[1, 2, 3].map((i) => (
+        <ScrollReveal key={i} className="mb-8">
+          <div className="rounded-lg border border-border bg-card p-8">
+            <h3 className="mb-2 text-lg font-bold">セクション {i}</h3>
+            <p className="text-muted-foreground">このカードはスクロールで表示されます。</p>
+          </div>
+        </ScrollReveal>
+      ))}
+    </div>
+  ),
+};

--- a/src/components/section.stories.tsx
+++ b/src/components/section.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { SectionContainer, SectionHeader } from './section';
-import { ThemeProvider } from './theme-provider';
 
 const meta = {
   title: 'Components/Section',
@@ -29,14 +28,12 @@ export const Default: Story = {
   },
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <SectionContainer>
-          <Story />
-          <div className="h-32 rounded-lg border border-dashed border-border bg-muted/30 p-4 text-muted-foreground">
-            Section content area
-          </div>
-        </SectionContainer>
-      </ThemeProvider>
+      <SectionContainer>
+        <Story />
+        <div className="h-32 rounded-lg border border-dashed border-border bg-muted/30 p-4 text-muted-foreground">
+          Section content area
+        </div>
+      </SectionContainer>
     ),
   ],
 };
@@ -50,14 +47,12 @@ export const AltBackground: Story = {
   },
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-        <SectionContainer alt>
-          <Story />
-          <div className="h-32 rounded-lg border border-dashed border-border bg-background/50 p-4 text-muted-foreground">
-            Alt section content area
-          </div>
-        </SectionContainer>
-      </ThemeProvider>
+      <SectionContainer alt>
+        <Story />
+        <div className="h-32 rounded-lg border border-dashed border-border bg-background/50 p-4 text-muted-foreground">
+          Alt section content area
+        </div>
+      </SectionContainer>
     ),
   ],
 };
@@ -72,14 +67,12 @@ export const DarkMode: Story = {
   globals: { theme: 'dark' },
   decorators: [
     (Story) => (
-      <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-        <SectionContainer>
-          <Story />
-          <div className="h-32 rounded-lg border border-dashed border-border bg-muted/30 p-4 text-muted-foreground">
-            Section content area
-          </div>
-        </SectionContainer>
-      </ThemeProvider>
+      <SectionContainer>
+        <Story />
+        <div className="h-32 rounded-lg border border-dashed border-border bg-muted/30 p-4 text-muted-foreground">
+          Section content area
+        </div>
+      </SectionContainer>
     ),
   ],
 };

--- a/src/components/section.stories.tsx
+++ b/src/components/section.stories.tsx
@@ -23,9 +23,9 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     label: 'Featured Projects',
-    title: 'Selected Work',
-    descriptionEn: 'Projects that showcase my engineering approach.',
-    description: '技術的なアプローチを示すプロジェクト集。',
+    title: 'Featured Work',
+    descriptionEn: 'Less friction, more flow.',
+    description: '開発者のワークフローを加速するために構築したツール群。',
   },
   decorators: [
     (Story) => (
@@ -45,8 +45,8 @@ export const AltBackground: Story = {
   args: {
     label: 'Latest Articles',
     title: 'Recent Articles',
-    descriptionEn: 'Thoughts on engineering and productivity.',
-    description: 'エンジニアリングと生産性についての考察。',
+    descriptionEn: 'Field notes from the trenches of developer productivity.',
+    description: '開発生産性の現場から得た知見。',
   },
   decorators: [
     (Story) => (
@@ -65,9 +65,9 @@ export const AltBackground: Story = {
 export const DarkMode: Story = {
   args: {
     label: 'Featured Projects',
-    title: 'Selected Work',
-    descriptionEn: 'Projects that showcase my engineering approach.',
-    description: '技術的なアプローチを示すプロジェクト集。',
+    title: 'Featured Work',
+    descriptionEn: 'Less friction, more flow.',
+    description: '開発者のワークフローを加速するために構築したツール群。',
   },
   globals: { theme: 'dark' },
   decorators: [

--- a/src/components/section.tsx
+++ b/src/components/section.tsx
@@ -50,7 +50,7 @@ export function SectionHeader({
         {title}
       </h2>
       {(descriptionEn ?? description) && (
-        <p className="max-w-[600px] text-[15px] leading-[1.7] text-muted-foreground">
+        <p className="max-w-[600px] text-[15px] leading-[1.7] text-text-secondary">
           {descriptionEn && <span className="font-medium text-foreground">{descriptionEn}</span>}
           {descriptionEn && description && ' — '}
           {description}

--- a/src/components/tag.stories.tsx
+++ b/src/components/tag.stories.tsx
@@ -12,7 +12,6 @@ import {
   WrenchIcon,
 } from 'lucide-react';
 import { Tag, TagList } from './tag';
-import { ThemeProvider } from './theme-provider';
 
 const sampleTags: TagType[] = [
   { label: 'React', category: 'frontend', icon: MonitorIcon },
@@ -47,37 +46,31 @@ type Story = StoryObj<typeof meta>;
 export const AllCategories: Story = {
   args: { tag: defaultTag },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="flex flex-wrap gap-2 p-4">
-        {sampleTags.map((tag) => (
-          <Tag key={tag.label} tag={tag} />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="flex flex-wrap gap-2 p-4">
+      {sampleTags.map((tag) => (
+        <Tag key={tag.label} tag={tag} />
+      ))}
+    </div>
   ),
 };
 
 export const SmallSize: Story = {
   args: { tag: defaultTag },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="flex flex-wrap gap-2 p-4">
-        {sampleTags.map((tag) => (
-          <Tag key={tag.label} tag={tag} size="sm" />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="flex flex-wrap gap-2 p-4">
+      {sampleTags.map((tag) => (
+        <Tag key={tag.label} tag={tag} size="sm" />
+      ))}
+    </div>
   ),
 };
 
 export const TagListExample: Story = {
   args: { tag: defaultTag },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="light" enableSystem={false}>
-      <div className="p-4">
-        <TagList tags={sampleTags.slice(0, 4)} />
-      </div>
-    </ThemeProvider>
+    <div className="p-4">
+      <TagList tags={sampleTags.slice(0, 4)} />
+    </div>
   ),
 };
 
@@ -85,12 +78,10 @@ export const DarkMode: Story = {
   args: { tag: defaultTag },
   globals: { theme: 'dark' },
   render: () => (
-    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      <div className="flex flex-wrap gap-2 rounded-lg bg-background p-4">
-        {sampleTags.map((tag) => (
-          <Tag key={tag.label} tag={tag} />
-        ))}
-      </div>
-    </ThemeProvider>
+    <div className="flex flex-wrap gap-2 rounded-lg bg-background p-4">
+      {sampleTags.map((tag) => (
+        <Tag key={tag.label} tag={tag} />
+      ))}
+    </div>
   ),
 };

--- a/src/components/tag.tsx
+++ b/src/components/tag.tsx
@@ -16,7 +16,7 @@ export function Tag({ tag, size = 'default', className }: TagProps) {
       className={cn(
         'inline-flex items-center gap-1 rounded border font-mono',
         'bg-[var(--tag-bg)] text-[var(--tag-text)] border-[var(--tag-border)]',
-        size === 'default' && 'px-2.5 py-0.5 text-[11px]',
+        size === 'default' && 'px-[9px] py-[3px] text-[11px]',
         size === 'sm' && 'px-[7px] py-px text-[10px]',
         className,
       )}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -22,7 +22,7 @@ export function ThemeToggle() {
           type="button"
           variant="outline"
           size="icon"
-          className="hover:bg-transparent hover:border-primary hover:text-primary"
+          className="hover:bg-transparent dark:hover:bg-transparent hover:border-primary hover:text-primary"
         >
           <SunIcon className="size-4 scale-100 rotate-0 transition-transform dark:scale-0 dark:-rotate-90" />
           <MoonIcon className="absolute size-4 scale-0 rotate-90 transition-transform dark:scale-100 dark:rotate-0" />

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -18,7 +18,12 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button type="button" variant="outline" size="icon">
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="hover:bg-transparent hover:border-primary hover:text-primary"
+        >
           <SunIcon className="size-4 scale-100 rotate-0 transition-transform dark:scale-0 dark:-rotate-90" />
           <MoonIcon className="absolute size-4 scale-0 rotate-90 transition-transform dark:scale-100 dark:rotate-0" />
           <span className="sr-only">テーマを切り替える</span>


### PR DESCRIPTION
## Summary
Epic #2 (Design System & Core Components) の最終チェック。蓄積されたフォローアップ 3 件を対応し、全 Story の視覚確認・データ整合性修正を完了。

### フォローアップ対応
| # | 項目 | 対応内容 |
|---|------|---------|
| 1 | Header hover スタイル | ThemeToggle + メニューボタンに `hover:bg-transparent hover:border-primary hover:text-primary` |
| 2 | Primary ボタン dark mode コントラスト | `--accent-gradient` dark を `#065a4e → #2db89a` に調整 (WCAG AA) |
| 3 | NoiseOverlay repaint | `will-change-transform` 追加 |

### 追加修正
- 全 Story のデモデータをモック v11 準拠に修正（文言・数値の不一致解消）
- 9 Story から不要な ThemeProvider を削除（test warning 11→2 に削減）
- モック dark --accent-gradient を実装と同期
- CLAUDE.md に Storybook Story ルール追記

## Changes
| File | Description |
|------|-------------|
| `src/components/theme-toggle.tsx` | hover: bg-transparent + border/text primary |
| `src/components/header.tsx` | メニューボタン hover: 同上 |
| `src/app/globals.css` | dark --accent-gradient 暗く調整 |
| `src/components/noise-overlay.tsx` | will-change-transform 追加 |
| `src/components/*-card.stories.tsx` | デモデータをモック準拠に |
| `src/components/section.stories.tsx` | 見出し文言をモック準拠に |
| 9 Story files | ThemeProvider 削除 (useTheme 不使用) |
| `design-mock/design-mockup-v11.html` | dark --accent-gradient 同期 |
| `CLAUDE.md` | Storybook Story ルール追記 |
| `vitest.config.ts` | 不要な onConsoleLog 削除 |

## Test plan
- [x] `bun build` 成功
- [x] `bunx vitest --project storybook` 全 36 tests PASS
- [x] Storybook 全 21 Story 視覚確認 PASS
- [x] ThemeToggle hover: 背景塗りつぶしなし確認
- [x] Story データがモック v11 と一致

**Note: Issue #43 は未完了項目があるため close しません（FilterTag, Pagination 等は後続 Epic で実装）**