### PR TITLE
feat: Projects ページ実装 (#4)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 import { ArticleCard } from '@/components/article-card';
 import { HeroSection } from '@/components/hero-section';
 import { ProjectCard } from '@/components/project-card';
-import { ScrollReveal } from '@/components/scroll-reveal';
+import { ScrollRevealList } from '@/components/scroll-reveal-list';
 import { SectionContainer, SectionHeader } from '@/components/section';
 import { ARTICLES } from '@/data/articles';
 import { PROJECTS } from '@/data/projects';
@@ -22,17 +22,15 @@ export default function Home() {
           descriptionEn="Less friction, more flow."
           description="開発者のワークフローを加速するために構築したツール群。"
         />
-        <ScrollReveal>
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5">
-            {PROJECTS.map((project, i) => (
-              <ProjectCard
-                key={project.slug}
-                project={{ ...project, href: '#' }}
-                className={i >= 2 ? 'max-lg:hidden' : undefined}
-              />
-            ))}
-          </div>
-        </ScrollReveal>
+        <ScrollRevealList className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5">
+          {PROJECTS.slice(0, 3).map((project, i) => (
+            <ProjectCard
+              key={project.slug}
+              project={{ ...project, href: '#' }}
+              className={i >= 2 ? 'max-lg:hidden' : undefined}
+            />
+          ))}
+        </ScrollRevealList>
       </SectionContainer>
 
       {/* #26: Recent Articles */}
@@ -43,18 +41,16 @@ export default function Home() {
           descriptionEn="Field notes from the trenches of developer productivity."
           description="開発生産性の現場から得た知見。"
         />
-        <ScrollReveal>
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5">
-            {ARTICLES.map((article, i) => (
-              <ArticleCard
-                key={article.slug}
-                article={article}
-                href="#"
-                className={i >= 2 ? 'max-lg:hidden' : undefined}
-              />
-            ))}
-          </div>
-        </ScrollReveal>
+        <ScrollRevealList className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5">
+          {ARTICLES.map((article, i) => (
+            <ArticleCard
+              key={article.slug}
+              article={article}
+              href="#"
+              className={i >= 2 ? 'max-lg:hidden' : undefined}
+            />
+          ))}
+        </ScrollRevealList>
       </SectionContainer>
     </>
   );

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,30 @@
+import { ProjectCard } from '@/components/project-card';
+import { ScrollRevealList } from '@/components/scroll-reveal-list';
+import { SectionContainer, SectionHeader } from '@/components/section';
+import { PROJECTS } from '@/data/projects';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Projects | Rymlab',
+  description: 'チームの速度を加速させるために設計・構築したツール群。',
+};
+
+// TODO #28: Replace static PROJECTS with microCMS SDK fetch + adapters behind 'use cache'
+
+export default function ProjectsPage() {
+  return (
+    <SectionContainer>
+      <SectionHeader
+        label="Projects"
+        title="All Projects"
+        descriptionEn="Tools engineered to multiply team velocity."
+        description="チームの速度を加速させるために設計・構築したツール群。"
+      />
+      <ScrollRevealList className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5">
+        {PROJECTS.map((project) => (
+          <ProjectCard key={project.slug} project={{ ...project, href: '#' }} />
+        ))}
+      </ScrollRevealList>
+    </SectionContainer>
+  );
+}

--- a/src/app/projects/projects-page.stories.tsx
+++ b/src/app/projects/projects-page.stories.tsx
@@ -8,8 +8,7 @@ const meta = {
     layout: 'fullscreen',
     docs: {
       description: {
-        component:
-          'Projects ページ。全プロジェクトを auto-fill グリッドで表示。',
+        component: 'Projects ページ。全プロジェクトを auto-fill グリッドで表示。',
       },
     },
   },

--- a/src/app/projects/projects-page.stories.tsx
+++ b/src/app/projects/projects-page.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import ProjectsPage from './page';
+
+const meta = {
+  title: 'Pages/Projects',
+  component: ProjectsPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Projects ページ。全プロジェクトを auto-fill グリッドで表示。',
+      },
+    },
+  },
+} satisfies Meta<typeof ProjectsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { theme: 'dark' },
+};

--- a/src/components/project-card.stories.tsx
+++ b/src/components/project-card.stories.tsx
@@ -1,60 +1,9 @@
-import type { Project } from '@/types/project';
+import { PROJECTS } from '@/data/projects';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import {
-  BarChart3Icon,
-  CloudIcon,
-  CodeIcon,
-  ContainerIcon,
-  LayoutDashboardIcon,
-  MonitorIcon,
-  ServerIcon,
-  ZapIcon,
-} from 'lucide-react';
 import { ProjectCard } from './project-card';
 
-const sampleProject: Project = {
-  slug: 'ci-cd-optimizer',
-  title: 'CI/CD Pipeline Optimizer',
-  description:
-    'ビルド時間を70%短縮するCI/CDパイプライン最適化ツール。キャッシュ戦略と並列実行の自動チューニング。',
-  role: 'Lead Engineer',
-  icon: ZapIcon,
-  tags: [
-    { label: 'GitHub Actions', category: 'infra', icon: CloudIcon },
-    { label: 'TypeScript', category: 'languages', icon: CodeIcon },
-    { label: 'Docker', category: 'infra', icon: ContainerIcon },
-  ],
-};
-
-const sampleProjects: Project[] = [
-  sampleProject,
-  {
-    slug: 'developer-portal',
-    title: 'Developer Portal',
-    description:
-      '社内開発者ポータル。サービスカタログ、ドキュメント検索、オンボーディング自動化を統合。',
-    role: 'Platform Engineer',
-    icon: LayoutDashboardIcon,
-    tags: [
-      { label: 'Next.js', category: 'frontend', icon: MonitorIcon },
-      { label: 'Go', category: 'backend', icon: ServerIcon },
-      { label: 'Backstage', category: 'infra', icon: CloudIcon },
-    ],
-  },
-  {
-    slug: 'devmetrics-dashboard',
-    title: 'DevMetrics Dashboard',
-    description:
-      'DORA メトリクス可視化ダッシュボード。デプロイ頻度、リードタイム、MTTR、変更失敗率を自動計測。',
-    role: 'OSS Author',
-    icon: BarChart3Icon,
-    tags: [
-      { label: 'React', category: 'frontend', icon: MonitorIcon },
-      { label: 'Python', category: 'languages', icon: CodeIcon },
-      { label: 'Grafana', category: 'performance', icon: BarChart3Icon },
-    ],
-  },
-];
+const sampleProject = { ...PROJECTS[0], href: '#' };
+const sampleProjects = PROJECTS.slice(0, 3).map((p) => ({ ...p, href: '#' }));
 
 const meta = {
   title: 'Components/ProjectCard',
@@ -90,7 +39,7 @@ export const Default: Story = {
 export const Grid: Story = {
   args: { project: sampleProject },
   render: () => (
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(320px,1fr))] gap-5 p-4">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5 p-4">
       {sampleProjects.map((p) => (
         <ProjectCard key={p.slug} project={p} />
       ))}

--- a/src/components/project-card.tsx
+++ b/src/components/project-card.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { TagList } from '@/components/tag';
 import { cn } from '@/lib/utils';
 import type { Project } from '@/types/project';
+import { getProjectHref } from '@/types/project';
 
 interface ProjectCardProps {
   readonly project: Project;
@@ -11,7 +12,7 @@ interface ProjectCardProps {
 
 export function ProjectCard({ project, className }: ProjectCardProps) {
   const Icon = project.icon;
-  const href = project.href ?? `/projects/${project.slug}`;
+  const href = getProjectHref(project);
 
   return (
     <Link

--- a/src/components/scroll-reveal-list.stories.tsx
+++ b/src/components/scroll-reveal-list.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { ScrollRevealList } from './scroll-reveal-list';
+
+const meta = {
+  title: 'Components/ScrollRevealList',
+  component: ScrollRevealList,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '1つの IntersectionObserver で子要素を個別に scroll reveal。グリッドアイテム等に最適。prefers-reduced-motion 対応。',
+      },
+    },
+  },
+} satisfies Meta<typeof ScrollRevealList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: null,
+  },
+  render: () => (
+    <div className="p-8">
+      <p className="mb-8 text-muted-foreground">下にスクロールしてください</p>
+      <div className="h-[80vh]" />
+      <ScrollRevealList className="grid grid-cols-[repeat(auto-fill,minmax(min(280px,100%),1fr))] gap-5">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="rounded-lg border border-border bg-card p-8">
+            <h3 className="mb-2 text-lg font-bold">カード {i}</h3>
+            <p className="text-muted-foreground">
+              このカードは個別にスクロールで表示されます。
+            </p>
+          </div>
+        ))}
+      </ScrollRevealList>
+    </div>
+  ),
+};
+
+export const DarkMode: Story = {
+  args: {
+    children: null,
+  },
+  globals: { theme: 'dark' },
+  render: () => (
+    <div className="p-8">
+      <p className="mb-8 text-muted-foreground">下にスクロールしてください</p>
+      <div className="h-[80vh]" />
+      <ScrollRevealList className="grid grid-cols-[repeat(auto-fill,minmax(min(280px,100%),1fr))] gap-5">
+        {[1, 2, 3, 4, 5, 6].map((i) => (
+          <div key={i} className="rounded-lg border border-border bg-card p-8">
+            <h3 className="mb-2 text-lg font-bold">カード {i}</h3>
+            <p className="text-muted-foreground">
+              このカードは個別にスクロールで表示されます。
+            </p>
+          </div>
+        ))}
+      </ScrollRevealList>
+    </div>
+  ),
+};

--- a/src/components/scroll-reveal-list.stories.tsx
+++ b/src/components/scroll-reveal-list.stories.tsx
@@ -31,9 +31,7 @@ export const Default: Story = {
         {[1, 2, 3, 4, 5, 6].map((i) => (
           <div key={i} className="rounded-lg border border-border bg-card p-8">
             <h3 className="mb-2 text-lg font-bold">カード {i}</h3>
-            <p className="text-muted-foreground">
-              このカードは個別にスクロールで表示されます。
-            </p>
+            <p className="text-muted-foreground">このカードは個別にスクロールで表示されます。</p>
           </div>
         ))}
       </ScrollRevealList>
@@ -54,9 +52,7 @@ export const DarkMode: Story = {
         {[1, 2, 3, 4, 5, 6].map((i) => (
           <div key={i} className="rounded-lg border border-border bg-card p-8">
             <h3 className="mb-2 text-lg font-bold">カード {i}</h3>
-            <p className="text-muted-foreground">
-              このカードは個別にスクロールで表示されます。
-            </p>
+            <p className="text-muted-foreground">このカードは個別にスクロールで表示されます。</p>
           </div>
         ))}
       </ScrollRevealList>

--- a/src/components/scroll-reveal-list.tsx
+++ b/src/components/scroll-reveal-list.tsx
@@ -19,11 +19,7 @@ interface ScrollRevealListProps {
  * グリッド等、複数アイテムを個別アニメーションさせる場合に使用。
  * 各 React 子要素は単一の DOM ノードであることを前提とする。
  */
-export function ScrollRevealList({
-  children,
-  className,
-  threshold = 0.1,
-}: ScrollRevealListProps) {
+export function ScrollRevealList({ children, className, threshold = 0.1 }: ScrollRevealListProps) {
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {

--- a/src/components/scroll-reveal-list.tsx
+++ b/src/components/scroll-reveal-list.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { Children, cloneElement, isValidElement, useEffect, useRef } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface ScrollRevealListProps {
+  readonly children: React.ReactNode;
+  readonly className?: string;
+  readonly threshold?: number;
+}
+
+/**
+ * 1つの IntersectionObserver で直下の子要素を個別に監視し、
+ * ビューポートに入ったタイミングで .visible を付与する。
+ * 子要素には SSR 時点で .reveal を付与し、初回描画のフラッシュを防止。
+ * IO 非対応環境や prefers-reduced-motion: reduce の場合は即座に
+ * .visible を付与しアニメーションをスキップする。
+ * グリッド等、複数アイテムを個別アニメーションさせる場合に使用。
+ * 各 React 子要素は単一の DOM ノードであることを前提とする。
+ */
+export function ScrollRevealList({
+  children,
+  className,
+  threshold = 0.1,
+}: ScrollRevealListProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const makeVisible = () => {
+      for (const child of container.children) {
+        child.classList.add('visible');
+      }
+    };
+
+    if (typeof IntersectionObserver === 'undefined') {
+      if (process.env.NODE_ENV === 'development') {
+        console.warn(
+          '[ScrollRevealList] IntersectionObserver is not available. Falling back to immediate visibility.',
+        );
+      }
+      makeVisible();
+      return;
+    }
+
+    const prefersReducedMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (prefersReducedMotion) {
+      makeVisible();
+      return;
+    }
+
+    const safeThreshold = Math.min(1, Math.max(0, threshold));
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+          }
+        }
+      },
+      { threshold: safeThreshold },
+    );
+
+    for (const child of container.children) {
+      observer.observe(child);
+    }
+
+    return () => observer.disconnect();
+  }, [threshold, children]);
+
+  const revealChildren = Children.map(children, (child) => {
+    if (!isValidElement<{ className?: string }>(child)) return child;
+    return cloneElement(child, {
+      className: cn('reveal', child.props.className),
+    });
+  });
+
+  return (
+    <div ref={ref} className={cn(className)}>
+      {revealChildren}
+    </div>
+  );
+}

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -3,15 +3,21 @@ import {
   CloudIcon,
   CodeIcon,
   ContainerIcon,
+  DatabaseIcon,
+  FlaskConicalIcon,
   LayoutDashboardIcon,
+  MessageCircleIcon,
   MonitorIcon,
+  PackageIcon,
   ServerIcon,
+  TerminalIcon,
+  WrenchIcon,
   ZapIcon,
 } from 'lucide-react';
 
 import type { Project } from '@/types/project';
 
-export const PROJECTS: readonly Project[] = [
+export const PROJECTS: readonly [Project, ...Project[]] = [
   {
     slug: 'ci-cd-optimizer',
     title: 'CI/CD Pipeline Optimizer',
@@ -49,6 +55,44 @@ export const PROJECTS: readonly Project[] = [
       { label: 'React', category: 'frontend', icon: MonitorIcon },
       { label: 'Python', category: 'languages', icon: CodeIcon },
       { label: 'Grafana', category: 'performance', icon: BarChart3Icon },
+    ],
+  },
+  {
+    slug: 'iac-template-generator',
+    title: 'IaC Template Generator',
+    description:
+      'Terraformモジュールを対話的に生成するCLIツール。社内標準に準拠したインフラ構成を数分でセットアップ。',
+    role: 'Infrastructure Engineer',
+    icon: TerminalIcon,
+    tags: [
+      { label: 'Terraform', category: 'infra', icon: CloudIcon },
+      { label: 'Go', category: 'backend', icon: ServerIcon },
+      { label: 'AWS', category: 'infra', icon: CloudIcon },
+    ],
+  },
+  {
+    slug: 'incident-response-bot',
+    title: 'Incident Response Bot',
+    description:
+      'Slack連携のインシデント対応Bot。アラート集約、エスカレーション、ポストモーテム自動生成。',
+    role: 'Full-stack Developer',
+    icon: MessageCircleIcon,
+    tags: [
+      { label: 'TypeScript', category: 'languages', icon: CodeIcon },
+      { label: 'Slack API', category: 'tools', icon: WrenchIcon },
+      { label: 'PostgreSQL', category: 'backend', icon: DatabaseIcon },
+    ],
+  },
+  {
+    slug: 'config-validator',
+    title: 'Config Validator',
+    description:
+      'ゼロ依存の設定ファイルバリデーションライブラリ。YAML/TOML/JSON対応、CI組み込み可能。',
+    role: 'OSS Author',
+    icon: PackageIcon,
+    tags: [
+      { label: 'TypeScript', category: 'languages', icon: CodeIcon },
+      { label: 'Vitest', category: 'testing', icon: FlaskConicalIcon },
     ],
   },
 ];

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -10,3 +10,8 @@ export interface Project {
   readonly tags: readonly Tag[];
   readonly href?: string;
 }
+
+/** Return the project's explicit href, falling back to the /projects/:slug route convention. */
+export function getProjectHref(project: Pick<Project, 'slug' | 'href'>): string {
+  return project.href ?? `/projects/${project.slug}`;
+}


### PR DESCRIPTION
## Summary
- `/projects` ルートを v12 モックに基づいて実装 (Epic #4, Task #27)
- `ScrollRevealList` コンポーネントを新規追加 — 1つの IntersectionObserver で子要素を個別に監視するグリッド向けスクロールアニメーション
- Home ページの Featured Work / Recent Articles も `ScrollRevealList` に統一
- プロジェクトデータ 3件追加 (計6件、全てモックから正確にコピー)

## Changes

### New files
- `src/app/projects/page.tsx` — Projects ページ (metadata export 付き)
- `src/app/projects/projects-page.stories.tsx` — Pages/Projects Story (Default + DarkMode)
- `src/components/scroll-reveal-list.tsx` — 共有 Observer コンポーネント
- `src/components/scroll-reveal-list.stories.tsx` — Components/ScrollRevealList Story

### Modified files
- `src/data/projects.ts` — 3プロジェクト追加、非空タプル型 `readonly [Project, ...Project[]]`
- `src/types/project.ts` — `getProjectHref()` ユーティリティ抽出
- `src/components/project-card.tsx` — `getProjectHref()` 使用
- `src/components/project-card.stories.tsx` — データ重複解消、`href: '#'` 追加、grid minmax 修正
- `src/app/page.tsx` — `ScrollRevealList` 導入、`PROJECTS.slice(0, 3)` に修正

## ScrollRevealList の設計
- 1 Observer で全子要素を `.observe()` — パフォーマンス最適
- `cloneElement` で SSR 時に `.reveal` を付与 (フラッシュ防止)
- `matchMedia` ガード、`threshold` クランプ、IO 非対応フォールバック
- `prefers-reduced-motion` 対応
- `children` を useEffect deps に含み動的データ対応

## Acceptance Criteria
- [x] プロジェクト一覧がグリッド表示される (auto-fill, minmax 320px)
- [x] カードの高さが均等化されている (flex + grow + mt-auto)
- [x] hover エフェクトが動作する
- [x] レスポンシブで 2カラム → 1カラムに切り替わる

## Test plan
- [x] `bun build` — 成功確認済み
- [x] `bun lint` — 成功確認済み
- [x] Storybook build — 成功確認済み
- [x] `/projects` ページのブラウザ表示確認
- [x] スクロールアニメーション動作確認
- [x] レスポンシブ (1024px / 768px / 480px) 確認
- [x] ダークモード確認

Closes #27
Relates to #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)