### PR TITLE
feat: About ページ実装 (#6, #32)

### DIFF
--- a/src/app/about/about-page.stories.tsx
+++ b/src/app/about/about-page.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import AboutPage from './page';
+
+const meta = {
+  title: 'Pages/About',
+  component: AboutPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'About ページ。Profile + Engineering Principles + Tech Stack / Toolbox。',
+      },
+    },
+  },
+} satisfies Meta<typeof AboutPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { theme: 'dark' },
+};

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,85 @@
+import { PrincipleCard } from '@/components/principle-card';
+import { ScrollRevealList } from '@/components/scroll-reveal-list';
+import { SectionContainer, SectionHeader } from '@/components/section';
+import { SocialIconBar } from '@/components/social-icon-bar';
+import { ToolboxCard } from '@/components/toolbox-card';
+import { PRINCIPLES, TOOLBOX_CATEGORIES } from '@/data/about';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'About | Rymlab',
+  description: 'Productivity Engineer Rym のプロフィール、エンジニアリング哲学、技術スタック。',
+};
+
+export default function AboutPage() {
+  return (
+    <SectionContainer>
+      {/* Profile */}
+      <div className="mb-14 grid grid-cols-[180px_1fr] items-start gap-9 max-md:grid-cols-1 max-md:text-center">
+        {/* Avatar */}
+        <div className="relative flex size-[180px] items-center justify-center overflow-hidden rounded-[14px] border border-border bg-secondary text-[56px] max-md:mx-auto">
+          <span aria-hidden="true">{'\u{1F468}\u200D\u{1F4BB}'}</span>
+          <div
+            className="absolute inset-0"
+            style={{
+              background: 'linear-gradient(135deg, var(--accent-glow) 0%, transparent 50%)',
+            }}
+          />
+        </div>
+
+        {/* Info */}
+        <div>
+          <h1 className="mb-[3px] text-[28px] font-extrabold">Rym</h1>
+          <p className="mb-4 font-mono text-[13px] text-primary">
+            Productivity Engineer &mdash; Tokyo, Japan
+          </p>
+
+          {/* Bio */}
+          <div className="mb-5 text-[14.5px] leading-[1.8] text-text-secondary max-md:text-left">
+            <p className="mb-2.5">
+              開発チームの生産性を最大化することに情熱を注いでいます。
+              <strong className="font-semibold text-foreground">CI/CDパイプラインの最適化</strong>、
+              <strong className="font-semibold text-foreground">開発者ツールの設計</strong>、
+              <strong className="font-semibold text-foreground">インフラ自動化</strong>
+              を通じて、エンジニアがコードに集中できる環境を構築します。
+            </p>
+            <p>
+              「計測し、自動化し、改善する」を信条に、日々の開発ワークフローをより良くすることが私のミッションです。
+            </p>
+          </div>
+
+          {/* Social Links */}
+          <SocialIconBar className="max-md:justify-center" />
+        </div>
+      </div>
+
+      {/* Engineering Principles */}
+      <SectionHeader
+        label="Engineering Principles"
+        title="What I Value"
+        descriptionEn="The compass that guides my engineering decisions."
+        description="エンジニアリングにおいて大切にしていること。"
+        className="mb-6 max-md:mb-6"
+      />
+      <ScrollRevealList className="mb-14 grid grid-cols-[repeat(auto-fill,minmax(min(260px,100%),1fr))] gap-4 max-md:grid-cols-2 max-[480px]:grid-cols-1">
+        {PRINCIPLES.map((principle) => (
+          <PrincipleCard key={principle.title} principle={principle} />
+        ))}
+      </ScrollRevealList>
+
+      {/* Tech Stack / Toolbox */}
+      <SectionHeader
+        label="Toolbox"
+        title="Tech Stack"
+        descriptionEn="Tools of the trade."
+        description="日々の開発で使っている技術とツール。"
+        className="mb-6 max-md:mb-6"
+      />
+      <ScrollRevealList className="grid grid-cols-[repeat(auto-fill,minmax(min(260px,100%),1fr))] gap-4">
+        {TOOLBOX_CATEGORIES.map((category) => (
+          <ToolboxCard key={category.title} category={category} />
+        ))}
+      </ScrollRevealList>
+    </SectionContainer>
+  );
+}

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,22 +1,4 @@
-import Link from 'next/link';
-
-import {
-  GitHubIcon,
-  LinkedInIcon,
-  QiitaIcon,
-  XIcon,
-  ZennIcon,
-} from '@/components/icons/social-icons';
-import { cn } from '@/lib/utils';
-
-// RSS は Issue #31 (RSS フィード実装) で追加予定
-const SOCIAL_LINKS = [
-  { href: 'https://github.com/rymetry', label: 'GitHub', icon: GitHubIcon },
-  { href: 'https://x.com/rymetry', label: 'X', icon: XIcon },
-  { href: 'https://linkedin.com/in/rymetry', label: 'LinkedIn', icon: LinkedInIcon },
-  { href: 'https://zenn.dev/rymetry', label: 'Zenn', icon: ZennIcon },
-  { href: 'https://qiita.com/rymetry', label: 'Qiita', icon: QiitaIcon },
-] as const;
+import { SocialIconBar } from '@/components/social-icon-bar';
 
 export function Footer() {
   return (
@@ -31,25 +13,7 @@ export function Footer() {
         </div>
 
         {/* Social Icons */}
-        <div className="flex gap-2 max-md:justify-center">
-          {SOCIAL_LINKS.map(({ href, label, icon: Icon }) => (
-            <Link
-              key={label}
-              href={href}
-              aria-label={label}
-              target={href.startsWith('/') ? undefined : '_blank'}
-              rel={href.startsWith('/') ? undefined : 'noopener noreferrer'}
-              className={cn(
-                'flex size-[34px] items-center justify-center rounded-[7px] border border-border',
-                'text-muted-foreground transition-colors duration-200',
-                'hover:border-primary hover:text-primary hover:bg-[var(--accent-glow)]',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-              )}
-            >
-              <Icon size={16} />
-            </Link>
-          ))}
-        </div>
+        <SocialIconBar className="max-md:justify-center" />
       </div>
     </footer>
   );

--- a/src/components/principle-card.tsx
+++ b/src/components/principle-card.tsx
@@ -1,0 +1,26 @@
+import type { Principle } from '@/data/about';
+import { cn } from '@/lib/utils';
+
+interface PrincipleCardProps {
+  readonly principle: Principle;
+  readonly className?: string;
+}
+
+export function PrincipleCard({ principle, className }: PrincipleCardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-[11px] border border-border bg-card p-[22px]',
+        'transition-[border-color,box-shadow] duration-200',
+        'hover:border-[var(--border-hover)] hover:shadow-[var(--card-shadow-hover)]',
+        className,
+      )}
+    >
+      <div className="mb-2.5 text-[28px]" aria-hidden="true">
+        {principle.emoji}
+      </div>
+      <h3 className="mb-1.5 text-[15px] font-bold">{principle.title}</h3>
+      <p className="text-[13.5px] leading-[1.6] text-text-secondary">{principle.description}</p>
+    </div>
+  );
+}

--- a/src/components/social-icon-bar.tsx
+++ b/src/components/social-icon-bar.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+
+import { SOCIAL_LINKS } from '@/data/social-links';
+import { cn } from '@/lib/utils';
+
+interface SocialIconBarProps {
+  readonly className?: string;
+}
+
+/** Renders a horizontal row of icon links from SOCIAL_LINKS. External links open in a new tab. */
+export function SocialIconBar({ className }: SocialIconBarProps) {
+  return (
+    <div className={cn('flex gap-2', className)}>
+      {SOCIAL_LINKS.map(({ href, label, icon: Icon }) => {
+        const isExternal = !href.startsWith('/');
+        return (
+          <Link
+            key={label}
+            href={href}
+            aria-label={label}
+            target={isExternal ? '_blank' : undefined}
+            rel={isExternal ? 'noopener noreferrer' : undefined}
+            className={cn(
+              'flex size-[34px] items-center justify-center rounded-[7px] border border-border',
+              'text-muted-foreground transition-colors duration-200',
+              'hover:border-primary hover:bg-[var(--accent-glow)] hover:text-primary',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+            )}
+          >
+            <Icon size={16} />
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/toolbox-card.tsx
+++ b/src/components/toolbox-card.tsx
@@ -1,0 +1,33 @@
+import type { ToolboxCategory } from '@/data/about';
+import { cn } from '@/lib/utils';
+
+interface ToolboxCardProps {
+  readonly category: ToolboxCategory;
+  readonly className?: string;
+}
+
+export function ToolboxCard({ category, className }: ToolboxCardProps) {
+  return (
+    <div className={cn('rounded-[11px] border border-border bg-card p-5', className)}>
+      <h3 className="mb-3.5 flex items-center gap-[7px] text-[13px] font-semibold">
+        <span aria-hidden="true">{category.emoji}</span>
+        {category.title}
+      </h3>
+      <div className="flex flex-wrap gap-1.5">
+        {category.items.map((item) => (
+          <span
+            key={item}
+            className={cn(
+              'rounded-[5px] border border-border bg-secondary px-[11px] py-[5px]',
+              'font-mono text-[12.5px] text-text-secondary',
+              'transition-[border-color,color,background] duration-200',
+              'hover:border-primary hover:bg-[var(--accent-glow)] hover:text-primary',
+            )}
+          >
+            {item}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/data/about.ts
+++ b/src/data/about.ts
@@ -1,0 +1,60 @@
+export interface Principle {
+  readonly emoji: string;
+  readonly title: string;
+  readonly description: string;
+}
+
+export interface ToolboxCategory {
+  readonly emoji: string;
+  readonly title: string;
+  readonly items: readonly string[];
+}
+
+export const PRINCIPLES: readonly [Principle, ...Principle[]] = [
+  {
+    emoji: '\u26A1',
+    title: 'Automate Relentlessly',
+    description:
+      '手作業を見つけたら自動化を考える。繰り返しの作業はシステムに任せ、人はクリエイティブな仕事に集中する。',
+  },
+  {
+    emoji: '\u{1F4A1}',
+    title: 'Question Assumptions',
+    description:
+      '前提を常に疑う。「なぜそうなっているのか」を問い続けることで、本質的な課題と最適な解決策が見えてくる。',
+  },
+  {
+    emoji: '\u2728',
+    title: 'Developer Experience',
+    description:
+      '開発者の生産性を最大化するツールと環境を提供する。優れた DX は、優れたプロダクトにつながる。',
+  },
+  {
+    emoji: '\u{1F680}',
+    title: 'Continuous Improvement',
+    description: '小さな改善を積み重ねる。1%の改善を100回繰り返せば、劇的な変化が生まれる。',
+  },
+];
+
+export const TOOLBOX_CATEGORIES: readonly [ToolboxCategory, ...ToolboxCategory[]] = [
+  {
+    emoji: '\u26A1',
+    title: 'Platform & CI/CD',
+    items: ['GitHub Actions', 'Terraform', 'Docker', 'AWS', 'Vercel'],
+  },
+  {
+    emoji: '\u{1F4BB}',
+    title: 'Languages',
+    items: ['TypeScript', 'Go', 'Python', 'Bash'],
+  },
+  {
+    emoji: '\u2699',
+    title: 'Frontend & Backend',
+    items: ['Next.js', 'React', 'Hono', 'PostgreSQL', 'Redis'],
+  },
+  {
+    emoji: '\u{1F6E0}',
+    title: 'Tools & Observability',
+    items: ['Grafana', 'Datadog', 'Linear', 'Neovim', 'Claude Code'],
+  },
+];

--- a/src/data/social-links.ts
+++ b/src/data/social-links.ts
@@ -1,0 +1,24 @@
+import type { ComponentType, SVGProps } from 'react';
+
+import {
+  GitHubIcon,
+  LinkedInIcon,
+  QiitaIcon,
+  XIcon,
+  ZennIcon,
+} from '@/components/icons/social-icons';
+
+export interface SocialLink {
+  readonly href: string;
+  readonly label: string;
+  readonly icon: ComponentType<SVGProps<SVGSVGElement> & { size?: number | string }>;
+}
+
+// TODO(#31): Add RSS
+export const SOCIAL_LINKS: readonly [SocialLink, ...SocialLink[]] = [
+  { href: 'https://github.com/rymetry', label: 'GitHub', icon: GitHubIcon },
+  { href: 'https://x.com/rymetry', label: 'X', icon: XIcon },
+  { href: 'https://linkedin.com/in/rymetry', label: 'LinkedIn', icon: LinkedInIcon },
+  { href: 'https://zenn.dev/rymetry', label: 'Zenn', icon: ZennIcon },
+  { href: 'https://qiita.com/rymetry', label: 'Qiita', icon: QiitaIcon },
+];


### PR DESCRIPTION
## Summary
- `/about` ページを v12 デザインモックに基づいて実装
- Profile (アバター + バイオ + ソーシャルリンク)、Engineering Principles (4カード)、Tech Stack / Toolbox (4カテゴリ) の3セクション構成
- `SOCIAL_LINKS` を Footer から共有モジュールに抽出し `SocialIconBar` コンポーネントに統一 (DRY化)

## Changes
| ファイル | 操作 |
|---------|------|
| `src/app/about/page.tsx` | NEW — About ページ本体 |
| `src/app/about/about-page.stories.tsx` | NEW — Storybook Story (Default + DarkMode) |
| `src/data/about.ts` | NEW — Principles + Toolbox 静的データ |
| `src/data/social-links.ts` | NEW — SOCIAL_LINKS 共有データ + SocialLink 型定義 |
| `src/components/social-icon-bar.tsx` | NEW — ソーシャルアイコン共有コンポーネント |
| `src/components/principle-card.tsx` | NEW — Principle カードコンポーネント |
| `src/components/toolbox-card.tsx` | NEW — Toolbox カテゴリコンポーネント |
| `src/components/footer.tsx` | EDIT — SocialIconBar に置き換え |

## Design Decisions
- Profile セクションは即時表示 (ScrollReveal なし)、カードグリッドは `ScrollRevealList`
- `h1` (名前) → `h2` (セクションタイトル) → `h3` (カードタイトル) のアクセシビリティ階層
- Avatar gradient を `50%` で止めてモックと一致
- Principles grid: `max-md:grid-cols-2 max-[480px]:grid-cols-1` の明示的レスポンシブオーバーライド

## Test plan
- [ ] `bun build` — 成功確認済み ✅
- [ ] `bun lint` — 成功確認済み ✅
- [ ] `bun storybook` で About ページの Default / DarkMode を目視確認
- [ ] `bun dev` → `/about` でブラウザ実機確認
- [ ] レスポンシブ確認 (1024px / 768px / 480px)
- [ ] ソーシャルリンクが新しいタブで開くことを確認
- [ ] Footer のソーシャルリンクが引き続き正常動作することを確認

## Follow-up (Issue #32 にコメント済み)
- 型定義を `src/types/about.ts` に移動
- `ToolboxCategory.items` を非空タプル化
- microCMS 統合時に `error.tsx` 追加

Closes #32
Relates to #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)