### PR TITLE
feat: カスタム 404 / Error ページ実装 (#66)

### DIFF
--- a/design-mock/design-mockup-v12.html
+++ b/design-mock/design-mockup-v12.html
@@ -198,6 +198,21 @@
   .s-desc { color: var(--text-secondary); font-size: 15px; margin-bottom: 40px; max-width: 600px; line-height: 1.7; }
   .s-desc-en { font-weight: 500; color: var(--text-primary); } /* v6: 600→500 */
 
+  /* ===== Error Pages (404 / Error) ===== */
+  .error-hero { background: var(--hero-bg); position: relative; overflow: hidden; min-height: calc(100vh - 60px - 50px); display: flex; align-items: center; justify-content: center; }
+  .error-hero::before { content: ''; position: absolute; inset: 0; background-image: radial-gradient(circle at 1px 1px, var(--dot-color) 1px, transparent 0); background-size: 28px 28px; }
+  .error-hero::after { content: ''; position: absolute; top: -30%; right: -10%; width: 600px; height: 600px; background: radial-gradient(ellipse, oklch(0.52 0.11 156 / 0.08) 0%, transparent 60%); pointer-events: none; }
+  .error-hero .hero-mesh { position: absolute; bottom: -20%; left: -10%; width: 500px; height: 500px; background: radial-gradient(ellipse, oklch(0.55 0.12 156 / 0.05) 0%, transparent 60%); pointer-events: none; }
+  .error-inner { position: relative; z-index: 1; text-align: center; max-width: 560px; padding: 0 24px; }
+  .error-code { font-family: var(--font-mono); font-size: clamp(80px, 15vw, 140px); font-weight: 800; line-height: 1; letter-spacing: -0.04em; background: var(--accent-gradient); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; margin-bottom: 12px; }
+  .error-title { font-family: var(--font-display); font-size: clamp(20px, 3vw, 28px); font-weight: 700; letter-spacing: -0.02em; margin-bottom: 12px; }
+  .error-desc { color: var(--text-secondary); font-size: 15px; line-height: 1.7; margin-bottom: 16px; }
+  .error-digest { font-family: var(--font-mono); font-size: 11px; color: var(--text-muted); margin-bottom: 28px; }
+  .error-terminal { background: #09090b; border: 1px solid #2a2a2f; border-radius: 11px; overflow: hidden; text-align: left; max-width: 400px; margin: 0 auto 32px; box-shadow: 0 12px 32px -8px rgba(0,0,0,0.3); }
+  .dark .error-terminal { border-color: #3f3f46; }
+  .error-terminal .t-body { padding: 14px 18px; font-size: 12px; line-height: 1.8; }
+  .error-cta { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+
   /* ===== Tags ===== */
   .tag { display: inline-flex; align-items: center; gap: 4px; padding: 3px 9px; background: var(--tag-bg); border: 1px solid var(--tag-border); border-radius: 4px; font-size: 11px; color: var(--tag-text); font-family: var(--font-mono); }
   .tag iconify-icon { font-size: 11px; flex-shrink: 0; }
@@ -479,6 +494,8 @@
     <button class="ctrl-btn" data-page="projects">Projects</button>
     <button class="ctrl-btn" data-page="article-detail">Article Detail</button>
     <button class="ctrl-btn" data-page="about">About</button>
+    <button class="ctrl-btn" data-page="404">404</button>
+    <button class="ctrl-btn" data-page="error">Error</button>
     <div class="ctrl-div"></div>
     <button class="ctrl-btn active" id="t-light">Light</button>
     <button class="ctrl-btn" id="t-dark">Dark</button>
@@ -838,6 +855,72 @@
       <div class="toolbox-cat"><h4>&#128736; Tools & Observability</h4><div class="toolbox-items"><span class="tb-item">Grafana</span><span class="tb-item">Datadog</span><span class="tb-item">Linear</span><span class="tb-item">Neovim</span><span class="tb-item">Claude Code</span></div></div>
     </div>
   </section>
+
+  <footer class="site-footer"><div class="footer-inner"><div class="footer-left"><div class="footer-logo">Rym<span class="a">lab</span></div><p class="footer-copy">&copy; 2026 Rymlab. All rights reserved.</p></div><div class="footer-icons"><a class="footer-icon" aria-label="GitHub"><iconify-icon icon="simple-icons:github"></iconify-icon></a><a class="footer-icon" aria-label="X"><iconify-icon icon="simple-icons:x"></iconify-icon></a><a class="footer-icon" aria-label="LinkedIn"><iconify-icon icon="simple-icons:linkedin"></iconify-icon></a><a class="footer-icon" aria-label="Zenn"><iconify-icon icon="simple-icons:zenn"></iconify-icon></a><a class="footer-icon" aria-label="Qiita"><iconify-icon icon="simple-icons:qiita"></iconify-icon></a><a class="footer-icon" aria-label="RSS"><iconify-icon icon="lucide:rss"></iconify-icon></a></div></div></footer>
+</div>
+
+<!-- ==================== 404 NOT FOUND ==================== -->
+<div class="page-section" id="page-404">
+  <header class="site-header"><div class="header-inner"><a class="logo">Rym<span class="a">lab</span></a><div class="header-right"><nav><ul class="nav-links"><li><a>Home</a></li><li><a>Articles</a></li><li><a>Projects</a></li><li><a>About</a></li></ul></nav><div class="header-actions"><button class="lang-toggle" aria-label="Switch language"><iconify-icon icon="lucide:globe"></iconify-icon> JA</button><button class="theme-toggle" aria-label="Toggle theme"><iconify-icon icon="lucide:sun" class="icon-sun"></iconify-icon><iconify-icon icon="lucide:moon" class="icon-moon"></iconify-icon></button>
+        <button class="menu-btn" aria-label="Toggle menu"><iconify-icon icon="lucide:menu" class="icon-menu"></iconify-icon><iconify-icon icon="lucide:x" class="icon-close"></iconify-icon></button></div></div></div><nav class="mobile-nav"><a>Home</a><a>Articles</a><a>Projects</a><a>About</a></nav><div class="menu-overlay"></div></header>
+
+  <div class="error-hero">
+    <div class="hero-mesh" aria-hidden="true"></div>
+    <div class="error-inner">
+      <p class="s-label anim-up" style="margin-bottom:6px">// NOT_FOUND</p>
+      <p class="error-code anim-up anim-up-2" aria-hidden="true">404</p>
+      <h1 class="error-title anim-up anim-up-3">Page Not Found</h1>
+      <p class="error-desc anim-up anim-up-3" style="margin-bottom:28px">お探しのページは存在しないか、移動された可能性があります。</p>
+
+      <div class="error-terminal anim-up anim-up-3">
+        <div class="t-bar"><div class="t-dot r"></div><div class="t-dot y"></div><div class="t-dot g"></div></div>
+        <div class="t-body">
+          <div class="t-line"><span class="pr">~</span> <span class="cm">curl</span> /unknown-path</div>
+          <div class="t-line"><span class="dim">&rarr;</span> <span style="color:#ef4444">404</span>: Resource not found</div>
+          <div class="t-line" style="margin-top:8px"><span class="pr">~</span> <span class="cursor"></span></div>
+        </div>
+      </div>
+
+      <div class="error-cta anim-up anim-up-4">
+        <a class="btn-p">ホームに戻る &rarr;</a>
+        <a class="btn-s">記事を探す</a>
+      </div>
+    </div>
+  </div>
+
+  <footer class="site-footer"><div class="footer-inner"><div class="footer-left"><div class="footer-logo">Rym<span class="a">lab</span></div><p class="footer-copy">&copy; 2026 Rymlab. All rights reserved.</p></div><div class="footer-icons"><a class="footer-icon" aria-label="GitHub"><iconify-icon icon="simple-icons:github"></iconify-icon></a><a class="footer-icon" aria-label="X"><iconify-icon icon="simple-icons:x"></iconify-icon></a><a class="footer-icon" aria-label="LinkedIn"><iconify-icon icon="simple-icons:linkedin"></iconify-icon></a><a class="footer-icon" aria-label="Zenn"><iconify-icon icon="simple-icons:zenn"></iconify-icon></a><a class="footer-icon" aria-label="Qiita"><iconify-icon icon="simple-icons:qiita"></iconify-icon></a><a class="footer-icon" aria-label="RSS"><iconify-icon icon="lucide:rss"></iconify-icon></a></div></div></footer>
+</div>
+
+<!-- ==================== ERROR ==================== -->
+<div class="page-section" id="page-error">
+  <header class="site-header"><div class="header-inner"><a class="logo">Rym<span class="a">lab</span></a><div class="header-right"><nav><ul class="nav-links"><li><a>Home</a></li><li><a>Articles</a></li><li><a>Projects</a></li><li><a>About</a></li></ul></nav><div class="header-actions"><button class="lang-toggle" aria-label="Switch language"><iconify-icon icon="lucide:globe"></iconify-icon> JA</button><button class="theme-toggle" aria-label="Toggle theme"><iconify-icon icon="lucide:sun" class="icon-sun"></iconify-icon><iconify-icon icon="lucide:moon" class="icon-moon"></iconify-icon></button>
+        <button class="menu-btn" aria-label="Toggle menu"><iconify-icon icon="lucide:menu" class="icon-menu"></iconify-icon><iconify-icon icon="lucide:x" class="icon-close"></iconify-icon></button></div></div></div><nav class="mobile-nav"><a>Home</a><a>Articles</a><a>Projects</a><a>About</a></nav><div class="menu-overlay"></div></header>
+
+  <div class="error-hero">
+    <div class="hero-mesh" aria-hidden="true"></div>
+    <div class="error-inner">
+      <p class="s-label anim-up" style="margin-bottom:6px">// ERROR</p>
+      <p class="error-code anim-up anim-up-2" aria-hidden="true" style="font-size: clamp(48px, 10vw, 80px);">Error</p>
+      <h1 class="error-title anim-up anim-up-3">Something Went Wrong</h1>
+      <p class="error-desc anim-up anim-up-3">予期しないエラーが発生しました。しばらくしてからもう一度お試しください。</p>
+      <p class="error-digest anim-up anim-up-3">Error ID: NEXT_RSC_ERR_xK9m2</p>
+
+      <div class="error-terminal anim-up anim-up-3">
+        <div class="t-bar"><div class="t-dot r"></div><div class="t-dot y"></div><div class="t-dot g"></div></div>
+        <div class="t-body">
+          <div class="t-line"><span class="pr">~</span> <span class="cm">bun run</span> start</div>
+          <div class="t-line"><span style="color:#ef4444">Error</span>: Unexpected runtime exception</div>
+          <div class="t-line"><span class="dim">&rarr;</span> Process exited with code 1</div>
+          <div class="t-line" style="margin-top:8px"><span class="pr">~</span> <span class="cursor"></span></div>
+        </div>
+      </div>
+
+      <div class="error-cta anim-up anim-up-4">
+        <button class="btn-p">リトライ &#8635;</button>
+        <a class="btn-s">ホームに戻る</a>
+      </div>
+    </div>
+  </div>
 
   <footer class="site-footer"><div class="footer-inner"><div class="footer-left"><div class="footer-logo">Rym<span class="a">lab</span></div><p class="footer-copy">&copy; 2026 Rymlab. All rights reserved.</p></div><div class="footer-icons"><a class="footer-icon" aria-label="GitHub"><iconify-icon icon="simple-icons:github"></iconify-icon></a><a class="footer-icon" aria-label="X"><iconify-icon icon="simple-icons:x"></iconify-icon></a><a class="footer-icon" aria-label="LinkedIn"><iconify-icon icon="simple-icons:linkedin"></iconify-icon></a><a class="footer-icon" aria-label="Zenn"><iconify-icon icon="simple-icons:zenn"></iconify-icon></a><a class="footer-icon" aria-label="Qiita"><iconify-icon icon="simple-icons:qiita"></iconify-icon></a><a class="footer-icon" aria-label="RSS"><iconify-icon icon="lucide:rss"></iconify-icon></a></div></div></footer>
 </div>

--- a/src/app/error.stories.tsx
+++ b/src/app/error.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import ErrorPage from './error';
+
+const meta = {
+  title: 'Pages/Error',
+  component: ErrorPage,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'ランタイムエラーページ。リトライボタン + ホームへの CTA。デザインシステム準拠。',
+      },
+    },
+  },
+  args: {
+    error: Object.assign(new Error('Unexpected runtime exception'), { digest: 'MOCK_DIGEST' }),
+    unstable_retry: () => {},
+  },
+} satisfies Meta<typeof ErrorPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { theme: 'dark' },
+};

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+import { ActionButton } from '@/components/action-button';
+import { cn } from '@/lib/utils';
+
+interface ErrorPageProps {
+  readonly error: Error & { digest?: string };
+  readonly unstable_retry: () => void;
+}
+
+export default function ErrorPage({ error, unstable_retry }: ErrorPageProps) {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    // TODO: Replace with error reporting service (Sentry, etc.)
+    console.error('[ErrorPage]', error);
+  }, [error]);
+
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  return (
+    <section
+      className={cn(
+        'relative flex min-h-full items-center justify-center overflow-hidden',
+        '[background:var(--hero-bg)]',
+        // Dot-grid overlay
+        'before:absolute before:inset-0',
+        'before:bg-[image:radial-gradient(circle_at_1px_1px,var(--dot-color)_1px,transparent_0)]',
+        'before:bg-[size:28px_28px]',
+        // Top-right mesh blob
+        'after:pointer-events-none after:absolute after:-top-[30%] after:-right-[10%]',
+        'after:h-[600px] after:w-[600px]',
+        'after:bg-[radial-gradient(ellipse,oklch(0.52_0.11_156/0.08)_0%,transparent_60%)]',
+      )}
+    >
+      {/* Bottom-left mesh blob */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-[20%] -left-[10%] h-[500px] w-[500px] bg-[radial-gradient(ellipse,oklch(0.55_0.12_156/0.05)_0%,transparent_60%)]"
+      />
+
+      <div className="relative z-[1] max-w-[560px] px-6 text-center max-md:px-4">
+        {/* Label */}
+        <p className="anim-up mb-1.5 font-mono text-xs uppercase tracking-[0.1em] text-primary">
+          {'// '}ERROR
+        </p>
+
+        {/* Error — decorative */}
+        <p
+          aria-hidden="true"
+          className="anim-up anim-up-2 mb-3 bg-[image:var(--accent-gradient)] bg-clip-text font-mono text-[clamp(48px,10vw,80px)] font-extrabold leading-none tracking-[-0.04em] text-transparent"
+        >
+          Error
+        </p>
+
+        {/* Heading + Description */}
+        <h1
+          ref={headingRef}
+          tabIndex={-1}
+          className="anim-up anim-up-3 mb-3 text-[clamp(20px,3vw,28px)] font-bold tracking-[-0.02em]"
+        >
+          Something Went Wrong
+        </h1>
+        <p className="anim-up anim-up-3 mb-4 text-[15px] leading-[1.7] text-text-secondary">
+          予期しないエラーが発生しました。しばらくしてからもう一度お試しください。
+        </p>
+        {error.digest && (
+          <p className="anim-up anim-up-3 mb-7 font-mono text-[11px] text-muted-foreground">
+            Error ID: {error.digest}
+          </p>
+        )}
+
+        {/* Terminal diagnostic */}
+        <div
+          aria-hidden="true"
+          className="anim-up anim-up-3 mx-auto mb-8 max-w-[400px] overflow-hidden rounded-[11px] border border-[var(--terminal-border)] bg-[var(--terminal-bg)] text-left shadow-[0_12px_32px_-8px_rgba(0,0,0,0.3)]"
+        >
+          {/* Traffic lights */}
+          <div className="flex gap-[7px] border-b border-[var(--terminal-border)] px-[14px] py-[10px]">
+            <div className="size-[11px] rounded-full bg-[#ef4444]" />
+            <div className="size-[11px] rounded-full bg-[#eab308]" />
+            <div className="size-[11px] rounded-full bg-[#22c55e]" />
+          </div>
+          <div className="px-[18px] py-[14px] font-mono text-xs leading-[1.8] text-[var(--terminal-text)]">
+            <div className="t-line">
+              <span className="text-[var(--terminal-prompt)]">~</span>{' '}
+              <span className="text-[var(--terminal-cmd)]">bun run</span> start
+            </div>
+            <div className="t-line">
+              <span className="text-[#ef4444]">Error</span>: Unexpected runtime exception
+            </div>
+            <div className="t-line">
+              <span className="text-[var(--terminal-dim)]">{'\u2192'}</span> Process exited with
+              code 1
+            </div>
+            <div className="t-line mt-2">
+              <span className="text-[var(--terminal-prompt)]">~</span>
+              <span
+                aria-hidden="true"
+                className="ml-[3px] inline-block h-[15px] w-[7px] align-middle [background:var(--terminal-cursor)] motion-safe:[animation:blink_1.2s_infinite]"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <div className="anim-up anim-up-4 flex flex-wrap justify-center gap-3">
+          <button
+            type="button"
+            onClick={unstable_retry}
+            className="inline-flex items-center gap-2 rounded-[9px] border-none bg-[image:var(--accent-gradient)] px-[22px] py-[11px] text-sm font-semibold text-white transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background motion-safe:hover:-translate-y-px hover:shadow-[var(--btn-primary-shadow)]"
+          >
+            リトライ ↻
+          </button>
+          <ActionButton href="/" variant="secondary">
+            ホームに戻る
+          </ActionButton>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface GlobalErrorProps {
+  readonly error: Error & { digest?: string };
+  readonly unstable_retry: () => void;
+}
+
+/**
+ * Last-resort error boundary — replaces the root layout when it crashes.
+ * Uses only inline styles and zero component/font/CSS imports so it cannot
+ * fail for the same reasons the root layout did (ThemeProvider, fonts, etc.).
+ */
+export default function GlobalError({ error, unstable_retry }: GlobalErrorProps) {
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  useEffect(() => {
+    // TODO: Replace with error reporting service (Sentry, etc.)
+    console.error('[GlobalError]', error);
+  }, [error]);
+
+  useEffect(() => {
+    headingRef.current?.focus();
+  }, []);
+
+  return (
+    <html lang="ja">
+      <head>
+        <title>Error | Rymlab</title>
+      </head>
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          backgroundColor: '#09090b',
+          color: '#f4f4f5',
+        }}
+      >
+        <div style={{ maxWidth: 480, textAlign: 'center', padding: '0 24px' }}>
+          {/* Label */}
+          <p
+            style={{
+              fontFamily: 'monospace',
+              fontSize: 12,
+              textTransform: 'uppercase',
+              letterSpacing: '0.1em',
+              opacity: 0.6,
+              marginBottom: 6,
+            }}
+          >
+            {'// '}FATAL_ERROR
+          </p>
+
+          {/* Error — decorative */}
+          <p
+            aria-hidden="true"
+            style={{
+              fontFamily: 'monospace',
+              fontSize: 'clamp(48px, 10vw, 80px)',
+              fontWeight: 800,
+              lineHeight: 1,
+              letterSpacing: '-0.04em',
+              background: 'linear-gradient(135deg, oklch(0.34 0.07 154), oklch(0.55 0.10 154))',
+              WebkitBackgroundClip: 'text',
+              WebkitTextFillColor: 'transparent',
+              marginBottom: 12,
+            }}
+          >
+            Error
+          </p>
+
+          <h1
+            ref={headingRef}
+            tabIndex={-1}
+            style={{
+              fontSize: 'clamp(20px, 3vw, 28px)',
+              fontWeight: 700,
+              marginBottom: 12,
+            }}
+          >
+            Something Went Wrong
+          </h1>
+
+          <p style={{ fontSize: 15, lineHeight: 1.7, opacity: 0.7, marginBottom: 8 }}>
+            予期しないエラーが発生しました。ページを再読み込みしてください。
+          </p>
+
+          {error.digest && (
+            <p
+              style={{
+                fontFamily: 'monospace',
+                fontSize: 11,
+                opacity: 0.4,
+                marginBottom: 24,
+              }}
+            >
+              Error ID: {error.digest}
+            </p>
+          )}
+
+          {/* CTA */}
+          <div
+            style={{
+              display: 'flex',
+              gap: 12,
+              justifyContent: 'center',
+              flexWrap: 'wrap',
+              marginTop: 24,
+            }}
+          >
+            <button
+              type="button"
+              onClick={unstable_retry}
+              style={{
+                padding: '11px 22px',
+                fontSize: 14,
+                fontWeight: 600,
+                color: '#fff',
+                background: 'linear-gradient(135deg, oklch(0.34 0.07 154), oklch(0.55 0.10 154))',
+                border: 'none',
+                borderRadius: 9,
+                cursor: 'pointer',
+              }}
+            >
+              リトライ ↻
+            </button>
+            {/* eslint-disable-next-line @next/next/no-html-link-for-pages -- global-error replaces root layout; plain <a> is safer than <Link> */}
+            <a
+              href="/"
+              style={{
+                padding: '11px 22px',
+                fontSize: 14,
+                fontWeight: 600,
+                color: '#f4f4f5',
+                background: 'transparent',
+                border: '1.5px solid rgba(244, 244, 245, 0.3)',
+                borderRadius: 9,
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+              }}
+            >
+              ホームに戻る
+            </a>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -46,7 +46,7 @@ export default function RootLayout({
       className={`${geist.variable} ${geistMono.variable} ${notoSansJP.variable} ${plemolJP.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <body className="min-h-full bg-background text-foreground">
+      <body className="flex min-h-full flex-col bg-background text-foreground">
         {/* Ensure animated content is visible when JS is disabled */}
         <noscript>
           <style>
@@ -68,7 +68,9 @@ export default function RootLayout({
             メインコンテンツへスキップ
           </a>
           <Header />
-          <main id="main-content">{children}</main>
+          <main id="main-content" className="flex-1">
+            {children}
+          </main>
           <Footer />
           <NoiseOverlay />
         </ThemeProvider>

--- a/src/app/not-found.stories.tsx
+++ b/src/app/not-found.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import NotFound from './not-found';
+
+const meta = {
+  title: 'Pages/NotFound',
+  component: NotFound,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '404 Not Found ページ。ターミナル風診断ブロック + ホームへの CTA。デザインシステム準拠。',
+      },
+    },
+  },
+} satisfies Meta<typeof NotFound>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const DarkMode: Story = {
+  globals: { theme: 'dark' },
+};

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,94 @@
+import { ActionButton } from '@/components/action-button';
+import { cn } from '@/lib/utils';
+
+export default function NotFound() {
+  return (
+    <section
+      className={cn(
+        'relative flex min-h-full items-center justify-center overflow-hidden',
+        '[background:var(--hero-bg)]',
+        // Dot-grid overlay
+        'before:absolute before:inset-0',
+        'before:bg-[image:radial-gradient(circle_at_1px_1px,var(--dot-color)_1px,transparent_0)]',
+        'before:bg-[size:28px_28px]',
+        // Top-right mesh blob
+        'after:pointer-events-none after:absolute after:-top-[30%] after:-right-[10%]',
+        'after:h-[600px] after:w-[600px]',
+        'after:bg-[radial-gradient(ellipse,oklch(0.52_0.11_156/0.08)_0%,transparent_60%)]',
+      )}
+    >
+      {/* Bottom-left mesh blob */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -bottom-[20%] -left-[10%] h-[500px] w-[500px] bg-[radial-gradient(ellipse,oklch(0.55_0.12_156/0.05)_0%,transparent_60%)]"
+      />
+
+      <div className="relative z-[1] max-w-[560px] px-6 text-center max-md:px-4">
+        {/* Label */}
+        <p className="anim-up mb-1.5 font-mono text-xs uppercase tracking-[0.1em] text-primary">
+          {'// '}NOT_FOUND
+        </p>
+
+        {/* 404 — decorative */}
+        <p
+          aria-hidden="true"
+          className="anim-up anim-up-2 mb-3 bg-[image:var(--accent-gradient)] bg-clip-text font-mono text-[clamp(80px,15vw,140px)] font-extrabold leading-none tracking-[-0.04em] text-transparent"
+        >
+          404
+        </p>
+
+        {/* Heading + Description */}
+        <h1
+          tabIndex={-1}
+          autoFocus
+          className="anim-up anim-up-3 mb-3 text-[clamp(20px,3vw,28px)] font-bold tracking-[-0.02em]"
+        >
+          Page Not Found
+        </h1>
+        <p className="anim-up anim-up-3 mb-7 text-[15px] leading-[1.7] text-text-secondary">
+          お探しのページは存在しないか、移動された可能性があります。
+        </p>
+
+        {/* Terminal diagnostic */}
+        <div
+          aria-hidden="true"
+          className="anim-up anim-up-3 mx-auto mb-8 max-w-[400px] overflow-hidden rounded-[11px] border border-[var(--terminal-border)] bg-[var(--terminal-bg)] text-left shadow-[0_12px_32px_-8px_rgba(0,0,0,0.3)]"
+        >
+          {/* Traffic lights */}
+          <div className="flex gap-[7px] border-b border-[var(--terminal-border)] px-[14px] py-[10px]">
+            <div className="size-[11px] rounded-full bg-[#ef4444]" />
+            <div className="size-[11px] rounded-full bg-[#eab308]" />
+            <div className="size-[11px] rounded-full bg-[#22c55e]" />
+          </div>
+          <div className="px-[18px] py-[14px] font-mono text-xs leading-[1.8] text-[var(--terminal-text)]">
+            <div className="t-line">
+              <span className="text-[var(--terminal-prompt)]">~</span>{' '}
+              <span className="text-[var(--terminal-cmd)]">curl</span> /unknown-path
+            </div>
+            <div className="t-line">
+              <span className="text-[var(--terminal-dim)]">{'\u2192'}</span>{' '}
+              <span className="text-[#ef4444]">404</span>: Resource not found
+            </div>
+            <div className="t-line mt-2">
+              <span className="text-[var(--terminal-prompt)]">~</span>
+              <span
+                aria-hidden="true"
+                className="ml-[3px] inline-block h-[15px] w-[7px] align-middle [background:var(--terminal-cursor)] motion-safe:[animation:blink_1.2s_infinite]"
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* CTA */}
+        <div className="anim-up anim-up-4 flex flex-wrap justify-center gap-3">
+          <ActionButton href="/" variant="primary">
+            ホームに戻る →
+          </ActionButton>
+          <ActionButton href="/articles" variant="secondary">
+            記事を探す
+          </ActionButton>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- **not-found.tsx**: ターミナル風診断ブロック + mesh blob + staggered fadeUp アニメーション。Hero セクションと統一したデザイン
- **error.tsx**: `unstable_retry()` でデータ再取得、`error.digest` 表示、`useRef` フォーカス管理
- **global-error.tsx**: inline styles のみのクラッシュ耐性フォールバック（ThemeProvider / フォント / CSS 非依存）
- **layout.tsx**: `flex-col` + `flex-1` で堅牢な full-height レイアウト（hardcoded calc 排除）
- **Storybook**: Default + DarkMode Stories
- **デザインモック**: 404 + Error セクション追加、コントロールバーボタン追加

### 解決する問題
Next.js デフォルトの 404/Error ページが `<style>` タグを `<main>` 内に注入し：
1. `.dark` クラスベースのダークモードを無視（`prefers-color-scheme` のみで判定）
2. 404 → 他ページへのナビゲーション時にスタイル汚染が残存
3. デザインシステムと不統一

### アクセシビリティ
- `<h1>` に意味のあるテキスト（「Page Not Found」/ 「Something Went Wrong」）
- 装飾的な 404/Error 数字は `<p aria-hidden="true">`
- `tabIndex={-1}` + `useEffect` / `autoFocus` でフォーカス管理
- `motion-safe:` でアニメーション制御、`prefers-reduced-motion` 対応
- ターミナルブロックは `aria-hidden="true"`

### レビュー履歴
- Phase 6 内部レビュー (3 agents) → 修正
- PR Review Toolkit (code-reviewer + silent-failure-hunter + code-simplifier) × 2 rounds
- Codex レビュー × 3 rounds
- ブラウザ実機確認 (Light / Dark / Mobile / ナビゲーション汚染テスト)

## Test plan
- [x] `bun dev` → `/nonexistent-page` で 404 ページ表示確認
- [x] ダークモード切替で 404 ページが正常表示
- [x] 404 → Home ナビゲーション後にスタイル汚染なし
- [x] モバイル (375px) でレスポンシブ確認
- [x] Storybook で Default + DarkMode Stories 確認
- [x] `bun build` / `bun lint` / `bun format:check` ALL PASS

Closes #66