### PR TITLE
[codex] Improve agent readiness docs and tooling

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,0 +1,45 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun:*)",
+      "Bash(bunx:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(ls:*)",
+      "Bash(cat:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(find:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"$CLAUDE_FILE_PATH\" | grep -qE '(^|/)\\.env(\\.|$)' && ! echo \"$CLAUDE_FILE_PATH\" | grep -qE '\\.example$' && echo \"BLOCK: .env files are protected\" >&2 && exit 1 || exit 0"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if [ -z \"$CLAUDE_FILE_PATH\" ] || [ ! -f \"$CLAUDE_FILE_PATH\" ]; then exit 0; fi; bunx prettier --write \"$CLAUDE_FILE_PATH\" 2>&1 || echo \"ERROR: Prettier failed on $CLAUDE_FILE_PATH\" >&2; exit 0",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    groups:
+      npm-patch-minor:
+        update-types:
+          - 'minor'
+          - 'patch'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agent Working Rules
+
+This file is the short entry point for Codex and other coding agents. Use [CLAUDE.md](./CLAUDE.md) as the detailed source of truth for product context, design rules, routes, and implementation notes.
+
+## Project Shape
+
+- App: Next.js 16 App Router, React 19, TypeScript 6, Bun.
+- Styling: Tailwind CSS v4, shadcn/ui New York, lucide-react.
+- Data today is mostly local static data under `src/data`; future CMS work is documented in `CLAUDE.md`.
+- Do not change runtime APIs, routes, component props, or data shapes when the task is only agent/tooling readiness.
+
+## Skills And Rules
+
+- Use `.agents/skills/shadcn` when adding or changing shadcn/ui components.
+- Use `.agents/skills/vercel-react-best-practices` for React/Next.js implementation and performance-sensitive changes.
+- Use `.agents/skills/vercel-composition-patterns` when changing reusable component APIs or component architecture.
+- Use `.agents/skills/web-design-guidelines` for UI/accessibility review work.
+- Use `.agents/skills/browser-use` or the available browser tooling for local visual verification.
+- Keep project-specific rules in this file and in `.agents/skills/*/rules`; do not add unsupported ad hoc rules directories.
+
+## Implementation Defaults
+
+- Prefer existing local patterns and components before introducing new abstractions.
+- Keep Storybook stories aligned with `design-mock/design-mockup-v12.html`; do not invent placeholder copy for stories.
+- Add a `DarkMode` story variant for new visual components and set `globals: { theme: 'dark' }`.
+- Wrap only components that directly or indirectly call `useTheme()` with `ThemeProvider` in stories.
+- Respect `prefers-reduced-motion` for animation work.
+- Never edit real `.env` files. Use `.env.example` only when an example is needed.
+
+## Verification
+
+Run the narrowest relevant checks while working. Before handing off a normal code or docs/config change, run:
+
+```bash
+bun run format:check
+bun run lint
+bun run typecheck
+bun run build
+```
+
+`bun run check` runs the same quality gate in sequence. `bun run test` is intentionally disabled until Epic #10 completes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,46 +1,53 @@
 # Rymlab — Portfolio & Blog
 
 ## Overview
+
 Productivity Engineer "Rym" のポートフォリオ & 技術ブログ。Site: Rymlab / Handle: rymetry / Deploy: Vercel / CMS: microCMS
 
 ## Tech Stack
-| Category | Technology |
-|----------|-----------|
-| Framework | Next.js 16 (App Router, `'use cache'`) |
-| Runtime | React 19, TypeScript 6 (strict), Bun |
-| Styling | Tailwind CSS v4, shadcn/ui (New York), Iconify (lucide + simple-icons) |
-| CMS | microCMS → unified (rehype-sanitize, rehype-prism-plus) |
-| Testing | Vitest (unit/component via Storybook) + Playwright (E2E) + Storybook 10 (@storybook/nextjs-vite) |
-| Lint | ESLint 9 (flat config) + Prettier 3 |
-| i18n | next-intl (Phase 3) / Dark Mode: next-themes |
+
+| Category  | Technology                                                                                       |
+| --------- | ------------------------------------------------------------------------------------------------ |
+| Framework | Next.js 16 (App Router, `'use cache'`)                                                           |
+| Runtime   | React 19, TypeScript 6 (strict), Bun                                                             |
+| Styling   | Tailwind CSS v4, shadcn/ui (New York), Iconify (lucide + simple-icons)                           |
+| CMS       | microCMS → unified (rehype-sanitize, rehype-prism-plus)                                          |
+| Testing   | Vitest (unit/component via Storybook) + Playwright (E2E) + Storybook 10 (@storybook/nextjs-vite) |
+| Lint      | ESLint 9 (flat config) + Prettier 3                                                              |
+| i18n      | next-intl (Phase 3) / Dark Mode: next-themes                                                     |
 
 ## Fonts
+
 - **Display/EN**: Geist (`next/font/google`) → `--font-display`
 - **JP**: Noto Sans JP (`next/font/google`) → `--font-sans-jp`
 - **Code**: PlemolJP HS (`next/font/local`, fallback: Geist Mono) → `--font-plemol` (composited as `--font-mono`)
 
 ## Design System
+
 最終デザイン: `design-mock/design-mockup-v12.html` (ブラウザで確認可能、コントロールバーでページ/テーマ切替)
 
 ### Colors — Palette D: Balanced Green 156°/154° (oklch)
+
 **Light** — bg: #fafafa / card: #fff / accent: oklch(0.52 0.11 156) / accent-2: oklch(0.55 0.12 156) / gradient: oklch(0.35 0.08 156)→oklch(0.55 0.12 156)
 **Dark** — bg: #09090b / card: #1a1a1f / accent: oklch(0.75 0.10 154) / accent-2: oklch(0.82 0.07 154) / gradient: oklch(0.34 0.07 154)→oklch(0.55 0.10 154)
 ダークモードは Hunt 効果補正で hue 154° (Light 156° から -2°)。アクセント・タグカテゴリ色は oklch 統一。ニュートラルトークン (bg, border 等) は hex 維持。text-muted は WCAG AA 準拠。
 
 ### Tags
-| Category | Color | Icon |
-|----------|-------|------|
-| Frontend | oklch(0.70 0.15 156) | lucide:monitor |
-| Backend | oklch(0.62 0.19 260) | lucide:server / database |
-| Infra/DevOps | oklch(0.61 0.22 293) | lucide:cloud / git-branch |
-| Languages | oklch(0.77 0.16 70) | lucide:code |
-| Tools/DX | oklch(0.66 0.21 354) | lucide:wrench / sparkles |
-| Security | oklch(0.64 0.21 25) | lucide:shield |
+
+| Category     | Color                | Icon                       |
+| ------------ | -------------------- | -------------------------- |
+| Frontend     | oklch(0.70 0.15 156) | lucide:monitor             |
+| Backend      | oklch(0.62 0.19 260) | lucide:server / database   |
+| Infra/DevOps | oklch(0.61 0.22 293) | lucide:cloud / git-branch  |
+| Languages    | oklch(0.77 0.16 70)  | lucide:code                |
+| Tools/DX     | oklch(0.66 0.21 354) | lucide:wrench / sparkles   |
+| Security     | oklch(0.64 0.21 25)  | lucide:shield              |
 | Perf/Metrics | oklch(0.71 0.13 215) | lucide:gauge / bar-chart-3 |
-| Testing | oklch(0.70 0.19 48) | lucide:flask-conical |
-| Release | oklch(0.63 0.23 304) | lucide:rocket |
+| Testing      | oklch(0.70 0.19 48)  | lucide:flask-conical       |
+| Release      | oklch(0.63 0.23 304) | lucide:rocket              |
 
 ### Animations
+
 - Hero: staggered fadeUp (0s/0.12s/0.24s/0.36s) + terminal typewriter (0.3s間隔) + float (6s, ±6px)
 - Cards: hover translateY(-2px) + green top bar + arrow + icon scale(1.08) rotate(-2deg)
 - Scroll: IntersectionObserver → .reveal → .visible
@@ -48,52 +55,63 @@ Productivity Engineer "Rym" のポートフォリオ & 技術ブログ。Site: R
 - `prefers-reduced-motion` を尊重すること
 
 ### Responsive
+
 1024px: グリッド調整, TOC非表示 / 768px: ハンバーガー (☰↔✕ + overlay), padding 16px / 480px: 1カラム
 
 ### Social Links
-GitHub, X, LinkedIn, Zenn, Qiita, RSS — simple-icons:* + lucide:rss
+
+GitHub, X, LinkedIn, Zenn, Qiita, RSS — simple-icons:\* + lucide:rss
 
 ## Pages
-| Route | Content |
-|-------|---------|
-| `/` | Hero (terminal animations) + Featured Work (非対称1大+2小) + Recent Articles (section-alt) |
-| `/projects` | プロジェクトグリッド (auto-fill) |
-| `/articles` | 検索 + タグフィルタ + ページネーション + Grid/List切替 |
-| `/articles/[slug]` | アイキャッチ + TOC (sticky 240px) + 関連記事 + 前後ナビ |
-| `/about` | Profile + Engineering Principles (4カード) + Tech Stack |
+
+| Route              | Content                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------ |
+| `/`                | Hero (terminal animations) + Featured Work (非対称1大+2小) + Recent Articles (section-alt) |
+| `/projects`        | プロジェクトグリッド (auto-fill)                                                           |
+| `/articles`        | 検索 + タグフィルタ + ページネーション + Grid/List切替                                     |
+| `/articles/[slug]` | アイキャッチ + TOC (sticky 240px) + 関連記事 + 前後ナビ                                    |
+| `/about`           | Profile + Engineering Principles (4カード) + Tech Stack                                    |
 
 ## Architecture
+
 ```
 microCMS → SDK → adaptArticle()/adaptTag() → 'use cache' (cacheLife 300s) → Component
                                                 ↓
                                     rehype (sanitize → highlight → TOC)
 ```
+
 - Adapter パターンで CMS スキーマとアプリ型を分離
 - テンプレート参照: github.com/rymetry/nextjs-portfolio-blog-template
 
 ## Accessibility
+
 focus-visible (緑アウトライン), aria-label (全アイコンボタン), skip link, 検索 aria-label
 
 ## GitHub Issues
+
 Epics #1-#10 (`epic`), Tasks #11-#44 (`task`)
+
 - Phase 1 (Core): #1,#2,#3,#4,#6 → #11-#27,#32,#42-#44
 - Phase 2 (Content): #5,#7,#9 → #28-#31,#33-#35,#38,#39
 - Phase 3 (Polish): #8,#10 → #36,#37,#40,#41
 
-## Claude Code Config
-- **Permissions**: bun, bunx, git, gh, ls, cat, find — 自動許可 (.claude/settings.local.json)
-- **Skills**: `.agents/skills/` — Vercel skills (react-best-practices, composition-patterns, web-design-guidelines, browser-use)
-- **Rules**: グローバル `~/.claude/rules/common/` に委任。プロジェクト固有ルールは `.claude/rules/` に追加
-- **Plugins**: everything-claude-code (skills/agents), superpowers, frontend-design, playwright, pr-review-toolkit, context7 (グローバル)
-- **Hooks** (個人設定 `.claude/settings.local.json`): PostToolUse Prettier自動フォーマット + PreToolUse .env保護
+## Claude Code / Agent Config
+
+- **Agent entrypoint**: `AGENTS.md` — Codex/agent 向けの短い作業ルール。詳細仕様はこの `CLAUDE.md` を source of truth とする
+- **Permissions example**: `.claude/settings.example.json` — コピーして `.claude/settings.local.json` として使う。個人設定は commit しない
+- **Skills**: `.agents/skills/` — shadcn, react-best-practices, composition-patterns, web-design-guidelines, browser-use
+- **Rules**: project-specific rules は `AGENTS.md` と `.agents/skills/*/rules` に集約する。unsupported な独自 rules ディレクトリは増やさない
+- **Hooks example**: `.claude/settings.example.json` に PostToolUse Prettier 自動フォーマットと PreToolUse `.env` 保護の例を含める
 
 ## Implementation Notes
+
 - 実装順: セットアップ (#11-#16,#42) → Story 先行 → コンポーネント → ページ組み立て
 - Storybook: @storybook/nextjs-vite v10.3.x (Next.js 16 対応済), Tailwind v4 は @tailwindcss/vite で統合
 - lefthook: pre-commit で `format:check` + `lint` を自動実行
 - Iconify: 実装時は @iconify/json でバンドル (CDN は FOUC リスク)。現状は lucide-react + インライン SVG (social icons) で統一
 
 ## Storybook Story ルール
+
 - **データはモック準拠**: Story のサンプルデータ（タイトル、説明、日付等）は `design-mock/design-mockup-v12.html` からコピーする。適当なプレースホルダーを使わない
 - **ThemeProvider は最小限**: `useTheme()` を直接/間接的に使用するコンポーネント (ThemeToggle, および ThemeToggle を内包する Header) のみ ThemeProvider でラップ。他は `preview.tsx` の `WithThemeClass` デコレータ + `globals: { theme: 'dark' }` でテーマ制御
 - **DarkMode Story**: 全コンポーネントに DarkMode variant を用意し、`globals: { theme: 'dark' }` を必ず設定する
@@ -102,17 +120,21 @@ Epics #1-#10 (`epic`), Tasks #11-#44 (`task`)
 - モック確認: `python3 -m http.server 8234` → localhost:8234/design-mock/design-mockup-v12.html
 
 ## Hooks Setup
-`.claude/settings.local.json` に以下を追加 (repo にはコミットしない):
-```json
-{
-  "hooks": {
-    "PostToolUse": [{"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "if [ -z \"$CLAUDE_FILE_PATH\" ] || [ ! -f \"$CLAUDE_FILE_PATH\" ]; then exit 0; fi; bunx prettier --write \"$CLAUDE_FILE_PATH\" 2>&1 || echo \"ERROR: Prettier failed on $CLAUDE_FILE_PATH\" >&2; exit 0", "timeout": 5000}]}],
-    "PreToolUse": [{"matcher": "Edit|Write", "hooks": [{"type": "command", "command": "echo \"$CLAUDE_FILE_PATH\" | grep -qE '(^|/)\\.env(\\.|$)' && ! echo \"$CLAUDE_FILE_PATH\" | grep -qE '\\.example$' && echo \"BLOCK: .env files are protected\" >&2 && exit 1 || exit 0"}]}]
-  }
-}
+
+Claude Code hooks are opt-in local settings. To enable the documented permissions and hooks:
+
+```bash
+mkdir -p .claude
+cp .claude/settings.example.json .claude/settings.local.json
 ```
 
+`.claude/settings.local.json` is ignored and must not be committed.
+
 ## Commands
+
 ```bash
-bun dev / bun build / bun test / bun storybook / bun lint / bun format
+bun run dev / bun run build / bun run storybook / bun run lint / bun run format
+bun run typecheck / bun run check
 ```
+
+`bun run test` is intentionally disabled until Epic #10 completes.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,80 @@
-# repo-template
+# Rymlab
 
-汎用リポジトリテンプレート。新規リポジトリの初期設定をワンコマンドで完了します。
+Productivity Engineer "Rym" のポートフォリオ & 技術ブログです。Next.js App Router、React 19、TypeScript、Tailwind CSS v4、shadcn/ui を使って構築しています。
 
-## 使い方
+## Tech Stack
 
-### 1. テンプレートからリポジトリを作成
+| Category  | Technology                                        |
+| --------- | ------------------------------------------------- |
+| Framework | Next.js 16, App Router                            |
+| Runtime   | React 19, TypeScript 6, Bun                       |
+| Styling   | Tailwind CSS v4, shadcn/ui New York, lucide-react |
+| Theme     | next-themes, light/dark                           |
+| Testing   | Storybook 10, Vitest browser project, Playwright  |
+| Quality   | ESLint 9, Prettier 3, lefthook                    |
+| Deploy    | Vercel                                            |
+
+詳細な設計、ページ構成、デザインルールは [CLAUDE.md](./CLAUDE.md) を参照してください。
+
+## Setup
 
 ```bash
-gh repo create my-new-project --template rymetry/repo-template --public --clone
-cd my-new-project
+bun install
+bunx lefthook install
 ```
 
-### 2. セットアップスクリプトを実行
+`lefthook` は pre-commit で `bun run format:check` と `bun run lint` を実行します。CI や worktree で不要な hook 書き換えを避けるため、`prepare` script では自動インストールしていません。
+
+Claude Code の個人設定を使う場合は、例をコピーしてから必要に応じて調整してください。
 
 ```bash
-bash .github/scripts/setup-repo.sh
+mkdir -p .claude
+cp .claude/settings.example.json .claude/settings.local.json
 ```
 
-以下が自動で設定されます:
+`.claude/settings.local.json` は個人設定なので commit しません。
 
-| 設定 | 内容 |
-|------|------|
-| **LICENSE** | プレースホルダーを実際の年・名前に置換 |
-| **SECURITY.md** | リポジトリ URL を自動設定 |
-| **Branch protection** | main に PR 必須 + 管理者バイパス |
-| **Auto-merge** | 有効化 |
-| **Dependabot** | alerts + security updates 有効化 |
-| **Actions** | Workflow permissions を Read only に設定 |
-| **不要機能** | Projects / Discussions / Wiki を OFF |
-| **ブランチ自動削除** | マージ後に自動削除 |
+## Commands
 
-### 3. README を書き換える
-
-このファイルをプロジェクト固有の内容に置き換えてください。
-
-## 含まれるファイル
-
-```
-.github/
-  workflows/dependabot-auto-merge.yml  # Dependabot patch/minor 自動マージ
-  ISSUE_TEMPLATE/
-    bug_report.yml                     # バグ報告テンプレート
-    feature_request.yml                # 機能リクエストテンプレート
-    config.yml                         # blank issue 許可
-  PULL_REQUEST_TEMPLATE.md             # PR テンプレート
-  scripts/setup-repo.sh                # GitHub 設定自動化スクリプト
-LICENSE                                # MIT License（英語 + 日本語）
-CODE_OF_CONDUCT.md                     # Contributor Covenant（日本語）
-SECURITY.md                            # 脆弱性報告ポリシー
-CONTRIBUTING.md                        # コントリビューションガイド
-.gitignore                             # 基本的な除外ルール
+```bash
+bun run dev          # Start local dev server
+bun run build        # Build production app
+bun run start        # Start built app
+bun run storybook    # Start Storybook on port 6006
+bun run build-storybook
+bun run format       # Format source files
+bun run format:check # Check formatting
+bun run lint
+bun run lint:fix
+bun run typecheck
+bun run check        # format:check + lint + typecheck + build
 ```
 
-## ライセンス
+`bun run test` は Epic #10 のテスト基盤完了まで未有効です。現時点では意図的に失敗します。
 
-[MIT License](./LICENSE)
+## Design Mock
+
+最終デザインの参照は `design-mock/design-mockup-v12.html` です。ブラウザで確認する場合は、リポジトリルートで以下を実行します。
+
+```bash
+python3 -m http.server 8234
+```
+
+その後、`http://localhost:8234/design-mock/design-mockup-v12.html` を開きます。実装の CSS 変数やスタイルを変更した場合は、対応するモックも同時に更新してください。
+
+## Quality Gate
+
+通常の変更後は以下を実行します。
+
+```bash
+bun run check
+```
+
+個別に切り分ける場合は、`bun run format:check`、`bun run lint`、`bun run typecheck`、`bun run build` の順で確認します。
+
+## Agent Entry Points
+
+- [AGENTS.md](./AGENTS.md): Codex や他 agent が最初に読む短い作業ルール
+- [CLAUDE.md](./CLAUDE.md): 詳細な仕様、デザイン、実装メモ
+- [.agents/skills](./.agents/skills): shadcn、React/Next.js、composition、web design、browser-use などのローカル skill
+- [skills-lock.json](./skills-lock.json): installed skills の出所と hash

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "rymetry-lab",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "bun@1.2.9",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",
@@ -9,6 +10,8 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "test": "echo 'Tests not yet configured (see Epic #10)' && exit 1",
+    "typecheck": "tsc --noEmit",
+    "check": "bun run format:check && bun run lint && bun run typecheck && bun run build",
     "format": "prettier --write 'src/**/*.{ts,tsx,css,json}'",
     "format:check": "prettier --check 'src/**/*.{ts,tsx,css,json}'",
     "storybook": "storybook dev -p 6006",


### PR DESCRIPTION
## Summary
- Replace the template README with project-specific onboarding, setup, commands, quality gate, and agent entry points.
- Add `AGENTS.md` and `.claude/settings.example.json` so Codex/Claude/other agents have a short rules entry point and opt-in local hook example.
- Add `bun run typecheck`, `bun run check`, and Dependabot npm weekly patch/minor grouping.

## Validation
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build` with network access for Google Fonts
- `bun run check` with network access for Google Fonts
- `bun run test` remains intentionally disabled until Epic #10 and exits with `Tests not yet configured (see Epic #10)`

## Notes
- App runtime behavior, routes, component props, and data shapes are unchanged.
- Standard sandbox builds fail while fetching Google Fonts through `next/font/google`; the build and full quality gate pass when network access is available.