### PR TITLE
[codex] Fix Storybook font variables

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,8 +1,9 @@
 import type { Preview } from '@storybook/nextjs-vite';
 import type { ReactRenderer } from '@storybook/react';
-import type { DecoratorFunction } from 'storybook/internal/types';
 import { useEffect } from 'react';
+import type { DecoratorFunction } from 'storybook/internal/types';
 import '../src/app/globals.css';
+import './storybook-fonts.css';
 
 const WithThemeClass: DecoratorFunction<ReactRenderer> = (Story, context) => {
   const theme = context.globals.theme ?? 'light';

--- a/.storybook/storybook-fonts.css
+++ b/.storybook/storybook-fonts.css
@@ -1,0 +1,12 @@
+@font-face {
+  font-family: "PlemolJP HS";
+  src: url("../src/app/fonts/PlemolJPHS-Regular.woff2") format("woff2");
+  font-display: swap;
+}
+
+:root {
+  --font-display: "Geist", ui-sans-serif, system-ui, sans-serif;
+  --font-sans-jp: "Noto Sans JP", "Hiragino Sans", "Yu Gothic", sans-serif;
+  --font-geist-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  --font-plemol: "PlemolJP HS", "Geist Mono", ui-monospace, monospace;
+}


### PR DESCRIPTION
## Summary

- Add Storybook-only font variable definitions for the app font tokens.
- Load the local PlemolJP woff2 in Storybook so `font-mono` stories no longer fall back to a generic monospace stack.
- Import the Storybook font CSS from `preview.tsx` so all stories receive the same CSS variables expected by `globals.css`.

## Root Cause

Storybook does not render the Next.js app `layout.tsx`, so the `next/font` variable classes attached to `<html>` in the app were missing in stories. Tailwind's `--font-sans` and `--font-mono` tokens reference those variables, which left Storybook using system fallbacks.

## Validation

- `bun run check`
- `bun run build-storybook`
- Confirmed the built Storybook CSS contains the font variable definitions and PlemolJP asset reference.

Fixes #68