### PR TITLE
Implement microCMS client and adapters

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,6 @@
 # microCMS (Get from microCMS dashboard > API Keys)
-MICROCMS_SERVICE_DOMAIN=
-MICROCMS_API_KEY=
+MICROCMS_SERVICE_DOMAIN=your-service-domain
+MICROCMS_API_KEY=your-read-api-key
 # API endpoint slugs (change if your CMS uses different endpoint names)
 MICROCMS_ARTICLES=articles
 MICROCMS_TAGS=tags
@@ -9,7 +9,7 @@ MICROCMS_TAGS=tags
 NEXT_PUBLIC_SITE_URL=http://localhost:3000
 
 # microCMS Preview (Draft Mode)
-MICROCMS_PREVIEW_SECRET=
+MICROCMS_PREVIEW_SECRET=your-preview-secret
 
 # Analytics (optional)
-NEXT_PUBLIC_GA_MEASUREMENT_ID=
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX

--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
+        "microcms-js-sdk": "^3.4.0",
         "next": "16.2.4",
         "next-themes": "^0.4.6",
         "radix-ui": "^1.4.3",
@@ -663,6 +664,8 @@
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
+    "async-retry": ["async-retry@1.3.3", "", { "dependencies": { "retry": "0.13.1" } }, "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw=="],
+
     "available-typed-arrays": ["available-typed-arrays@1.0.7", "", { "dependencies": { "possible-typed-array-names": "^1.0.0" } }, "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ=="],
 
     "axe-core": ["axe-core@4.11.1", "", {}, "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A=="],
@@ -1095,6 +1098,8 @@
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
+    "microcms-js-sdk": ["microcms-js-sdk@3.4.0", "", { "dependencies": { "async-retry": "^1.3.3" } }, "sha512-WJDHNHZlgyO7tzcEnnUaKOZDD3l5tnQjqDb32zWYt4H4auLbx+yc9yHHzcNn1vIGkF4xFW5gbLlZnlIDnMq0+A=="],
+
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
@@ -1228,6 +1233,8 @@
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 

--- a/design-mock/design-mockup-v12.html
+++ b/design-mock/design-mockup-v12.html
@@ -275,6 +275,17 @@
   .art-card .art-desc { display: none; }
   .art-tags { display: flex; gap: 5px; flex-wrap: wrap; }
 
+  /* ===== Loading skeletons ===== */
+  @keyframes skeletonPulse { 0%, 100% { opacity: .62; } 50% { opacity: 1; } }
+  .skel { display: block; border-radius: 6px; background: var(--bg-secondary); border: 1px solid transparent; animation: skeletonPulse 1.4s ease-in-out infinite; }
+  .skel-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 11px; overflow: hidden; }
+  .skel-card .art-thumb { border-radius: 0; }
+  .skel-body { padding: 20px; }
+  .skel-row { display: flex; gap: 10px; margin-bottom: 12px; }
+  .loading-hero-grid { display: grid; grid-template-columns: 1.05fr .95fr; gap: 48px; align-items: center; min-height: 420px; padding: 32px 0; }
+  .loading-article-shell { max-width: 980px; margin: 0 auto; }
+  .loading-article-grid { display: grid; grid-template-columns: 1fr 240px; gap: 40px; align-items: start; }
+
   .list-view .art-card { display: grid; grid-template-columns: 200px 1fr; }
   .list-view .art-thumb { height: 100%; min-height: 140px; }
   .list-view .art-body { padding: 20px 24px; display: flex; flex-direction: column; justify-content: center; }
@@ -434,6 +445,8 @@
     .nav-links { gap: 20px; }
     .section { padding: 56px 24px; }
     .hero { padding: 64px 0 48px; }
+    .loading-article-grid { grid-template-columns: 1fr; }
+    .loading-article-grid .toc-card { display: none; }
   }
   @media (max-width: 768px) {
     /* v8: hamburger menu */
@@ -441,6 +454,7 @@
     .menu-btn { display: flex; }
     .header-right { gap: 8px; }
     .hero-inner { grid-template-columns: 1fr; }
+    .loading-hero-grid { grid-template-columns: 1fr; min-height: auto; }
     .hero-visual .terminal { display: none; }
     .terminal-mobile { display: block; background: #09090b; border: 1px solid #2a2a2f; border-radius: 9px; padding: 14px 18px; margin-top: 24px; font-family: var(--font-mono); font-size: 12px; color: #a1a1aa; line-height: 1.6; }
     .terminal-mobile .pr { color: #5eead4; } .terminal-mobile .hl { color: #99f6e4; }
@@ -494,6 +508,7 @@
     <button class="ctrl-btn" data-page="projects">Projects</button>
     <button class="ctrl-btn" data-page="article-detail">Article Detail</button>
     <button class="ctrl-btn" data-page="about">About</button>
+    <button class="ctrl-btn" data-page="loading">Loading</button>
     <button class="ctrl-btn" data-page="404">404</button>
     <button class="ctrl-btn" data-page="error">Error</button>
     <div class="ctrl-div"></div>
@@ -853,6 +868,63 @@
       <div class="toolbox-cat"><h4>&#128187; Languages</h4><div class="toolbox-items"><span class="tb-item">TypeScript</span><span class="tb-item">Go</span><span class="tb-item">Python</span><span class="tb-item">Bash</span></div></div>
       <div class="toolbox-cat"><h4>&#9881; Frontend & Backend</h4><div class="toolbox-items"><span class="tb-item">Next.js</span><span class="tb-item">React</span><span class="tb-item">Hono</span><span class="tb-item">PostgreSQL</span><span class="tb-item">Redis</span></div></div>
       <div class="toolbox-cat"><h4>&#128736; Tools & Observability</h4><div class="toolbox-items"><span class="tb-item">Grafana</span><span class="tb-item">Datadog</span><span class="tb-item">Linear</span><span class="tb-item">Neovim</span><span class="tb-item">Claude Code</span></div></div>
+    </div>
+  </section>
+
+  <footer class="site-footer"><div class="footer-inner"><div class="footer-left"><div class="footer-logo">Rym<span class="a">lab</span></div><p class="footer-copy">&copy; 2026 Rymlab. All rights reserved.</p></div><div class="footer-icons"><a class="footer-icon" aria-label="GitHub"><iconify-icon icon="simple-icons:github"></iconify-icon></a><a class="footer-icon" aria-label="X"><iconify-icon icon="simple-icons:x"></iconify-icon></a><a class="footer-icon" aria-label="LinkedIn"><iconify-icon icon="simple-icons:linkedin"></iconify-icon></a><a class="footer-icon" aria-label="Zenn"><iconify-icon icon="simple-icons:zenn"></iconify-icon></a><a class="footer-icon" aria-label="Qiita"><iconify-icon icon="simple-icons:qiita"></iconify-icon></a><a class="footer-icon" aria-label="RSS"><iconify-icon icon="lucide:rss"></iconify-icon></a></div></div></footer>
+</div>
+
+<!-- ==================== LOADING ==================== -->
+<div class="page-section" id="page-loading">
+  <header class="site-header"><div class="header-inner"><a class="logo">Rym<span class="a">lab</span></a><div class="header-right"><nav><ul class="nav-links"><li><a class="active">Home</a></li><li><a>Articles</a></li><li><a>Projects</a></li><li><a>About</a></li></ul></nav><div class="header-actions"><button class="lang-toggle" aria-label="Switch language"><iconify-icon icon="lucide:globe"></iconify-icon> JA</button><button class="theme-toggle" aria-label="Toggle theme"><iconify-icon icon="lucide:sun" class="icon-sun"></iconify-icon><iconify-icon icon="lucide:moon" class="icon-moon"></iconify-icon></button>
+        <button class="menu-btn" aria-label="Toggle menu"><iconify-icon icon="lucide:menu" class="icon-menu"></iconify-icon><iconify-icon icon="lucide:x" class="icon-close"></iconify-icon></button></div></div></div><nav class="mobile-nav"><a class="active">Home</a><a>Articles</a><a>Projects</a><a>About</a></nav><div class="menu-overlay"></div></header>
+
+  <section class="section">
+    <p class="s-label">// Loading</p>
+    <h2 class="s-title">Home Loading</h2>
+    <div class="loading-hero-grid">
+      <div>
+        <span class="skel" style="width:160px;height:16px;margin-bottom:20px"></span>
+        <span class="skel" style="width:100%;max-width:620px;height:48px;margin-bottom:12px"></span>
+        <span class="skel" style="width:82%;max-width:520px;height:48px;margin-bottom:24px"></span>
+        <span class="skel" style="width:100%;max-width:560px;height:20px;margin-bottom:32px"></span>
+        <div class="skel-row"><span class="skel" style="width:144px;height:44px"></span><span class="skel" style="width:112px;height:44px"></span></div>
+      </div>
+      <span class="skel" style="height:320px;border-radius:11px;border-color:var(--border);background:var(--bg-card)"></span>
+    </div>
+  </section>
+
+  <div class="section-alt">
+  <section class="section" style="padding-top:64px;padding-bottom:64px">
+    <p class="s-label">// Articles</p>
+    <h2 class="s-title">Articles Loading</h2>
+    <div class="filter-bar">
+      <div class="filter-row"><span class="skel" style="height:44px;flex:1;border-color:var(--border);background:var(--bg-card)"></span><span class="skel" style="width:44px;height:44px;border-color:var(--border);background:var(--bg-card)"></span><span class="skel" style="width:44px;height:44px;border-color:var(--border);background:var(--bg-card)"></span></div>
+    </div>
+    <div class="art-grid">
+      <div class="skel-card"><span class="skel art-thumb"></span><div class="skel-body"><div class="skel-row"><span class="skel" style="width:80px;height:12px"></span><span class="skel" style="width:56px;height:12px"></span></div><span class="skel" style="height:16px;width:90%;margin-bottom:10px"></span><span class="skel" style="height:16px;width:70%;margin-bottom:16px"></span><div class="skel-row"><span class="skel" style="width:64px;height:20px"></span><span class="skel" style="width:80px;height:20px"></span></div></div></div>
+      <div class="skel-card"><span class="skel art-thumb"></span><div class="skel-body"><div class="skel-row"><span class="skel" style="width:80px;height:12px"></span><span class="skel" style="width:56px;height:12px"></span></div><span class="skel" style="height:16px;width:86%;margin-bottom:10px"></span><span class="skel" style="height:16px;width:62%;margin-bottom:16px"></span><div class="skel-row"><span class="skel" style="width:72px;height:20px"></span><span class="skel" style="width:88px;height:20px"></span></div></div></div>
+      <div class="skel-card"><span class="skel art-thumb"></span><div class="skel-body"><div class="skel-row"><span class="skel" style="width:80px;height:12px"></span><span class="skel" style="width:56px;height:12px"></span></div><span class="skel" style="height:16px;width:92%;margin-bottom:10px"></span><span class="skel" style="height:16px;width:76%;margin-bottom:16px"></span><div class="skel-row"><span class="skel" style="width:64px;height:20px"></span><span class="skel" style="width:80px;height:20px"></span></div></div></div>
+    </div>
+  </section>
+  </div>
+
+  <section class="section">
+    <p class="s-label">// Article Detail</p>
+    <h2 class="s-title">Detail Loading</h2>
+    <div class="loading-article-shell">
+      <span class="skel" style="width:112px;height:16px;margin-bottom:20px"></span>
+      <span class="skel" style="width:100%;height:40px;margin-bottom:12px"></span>
+      <span class="skel" style="width:72%;height:40px;margin-bottom:24px"></span>
+      <div class="skel-row"><span class="skel" style="width:80px;height:20px"></span><span class="skel" style="width:96px;height:20px"></span></div>
+      <span class="skel" style="width:100%;aspect-ratio:1200/630;border-radius:11px;border-color:var(--border);background:var(--bg-card);margin:28px 0 40px"></span>
+      <div class="loading-article-grid">
+        <div>
+          <span class="skel" style="height:16px;margin-bottom:16px"></span><span class="skel" style="height:16px;margin-bottom:16px"></span><span class="skel" style="height:16px;width:76%;margin-bottom:16px"></span>
+          <span class="skel" style="height:16px;margin-bottom:16px"></span><span class="skel" style="height:16px;margin-bottom:16px"></span><span class="skel" style="height:16px;width:76%"></span>
+        </div>
+        <div class="toc-card"><span class="skel" style="height:16px;width:80px;margin-bottom:14px"></span><span class="skel" style="height:12px;margin-bottom:10px"></span><span class="skel" style="height:12px;width:84%;margin-bottom:10px"></span><span class="skel" style="height:12px;width:68%"></span></div>
+      </div>
     </div>
   </section>
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
+    "microcms-js-sdk": "^3.4.0",
     "next": "16.2.4",
     "next-themes": "^0.4.6",
     "radix-ui": "^1.4.3",

--- a/src/app/articles/[slug]/loading.tsx
+++ b/src/app/articles/[slug]/loading.tsx
@@ -1,0 +1,5 @@
+import { ArticleDetailLoadingState } from '@/components/loading-state';
+
+export default function Loading() {
+  return <ArticleDetailLoadingState />;
+}

--- a/src/app/articles/loading.tsx
+++ b/src/app/articles/loading.tsx
@@ -1,0 +1,5 @@
+import { ArticlesLoadingState } from '@/components/loading-state';
+
+export default function Loading() {
+  return <ArticlesLoadingState />;
+}

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { HomeLoadingState } from '@/components/loading-state';
+
+export default function Loading() {
+  return <HomeLoadingState />;
+}

--- a/src/components/loading-state.stories.tsx
+++ b/src/components/loading-state.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ArticleDetailLoadingState, ArticlesLoadingState, HomeLoadingState } from './loading-state';
+
+const meta = {
+  title: 'Components/LoadingState',
+  component: HomeLoadingState,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: 'microCMS 導入時の App Router loading.tsx で使う skeleton states。',
+      },
+    },
+  },
+} satisfies Meta<typeof HomeLoadingState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Home: Story = {};
+
+export const Articles: Story = {
+  render: () => <ArticlesLoadingState />,
+};
+
+export const ArticleDetail: Story = {
+  render: () => <ArticleDetailLoadingState />,
+};
+
+export const DarkMode: Story = {
+  globals: { theme: 'dark' },
+};

--- a/src/components/loading-state.tsx
+++ b/src/components/loading-state.tsx
@@ -1,0 +1,132 @@
+import { SectionContainer, SectionHeader } from '@/components/section';
+import { cn } from '@/lib/utils';
+
+function Skeleton({ className }: { readonly className?: string }) {
+  return (
+    <div
+      className={cn('animate-pulse rounded bg-muted [animation-duration:1.4s]', className)}
+      aria-hidden="true"
+    />
+  );
+}
+
+function CardSkeleton({ compact = false }: { readonly compact?: boolean }) {
+  return (
+    <div
+      className={cn(
+        'overflow-hidden rounded-[11px] border border-border bg-card',
+        compact ? 'grid grid-cols-[120px_1fr] max-[480px]:grid-cols-[80px_1fr]' : 'flex flex-col',
+      )}
+    >
+      <Skeleton className={compact ? 'min-h-[90px] rounded-none' : 'h-40 rounded-none'} />
+      <div className={cn('flex flex-col', compact ? 'justify-center px-4.5 py-3.5' : 'p-5')}>
+        <div className="mb-3 flex gap-2.5">
+          <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-3 w-14" />
+        </div>
+        <Skeleton className={cn('mb-2.5 h-4', compact ? 'w-[82%]' : 'w-[90%]')} />
+        <Skeleton className={cn('mb-4 h-4', compact ? 'w-[58%]' : 'w-[70%]')} />
+        <div className="flex flex-wrap gap-[5px]">
+          <Skeleton className="h-5 w-16 rounded border border-border" />
+          <Skeleton className="h-5 w-20 rounded border border-border" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function HomeLoadingState() {
+  return (
+    <div role="status" aria-label="コンテンツを読み込み中">
+      <span className="sr-only">コンテンツを読み込み中</span>
+      <SectionContainer>
+        <div className="grid min-h-[420px] items-center gap-10 py-8 lg:grid-cols-[1.05fr_0.95fr]">
+          <div>
+            <Skeleton className="mb-5 h-4 w-40" />
+            <Skeleton className="mb-3 h-12 w-full max-w-[620px]" />
+            <Skeleton className="mb-6 h-12 w-[82%] max-w-[520px]" />
+            <Skeleton className="mb-8 h-5 w-full max-w-[560px]" />
+            <div className="flex gap-3">
+              <Skeleton className="h-11 w-36 rounded-md" />
+              <Skeleton className="h-11 w-28 rounded-md" />
+            </div>
+          </div>
+          <Skeleton className="h-[320px] rounded-[11px] border border-border bg-card" />
+        </div>
+      </SectionContainer>
+
+      <SectionContainer alt>
+        <SectionHeader label="Latest Articles" title="Recent Articles" />
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5">
+          {Array.from({ length: 3 }, (_, index) => (
+            <CardSkeleton key={index} />
+          ))}
+        </div>
+      </SectionContainer>
+    </div>
+  );
+}
+
+export function ArticlesLoadingState() {
+  return (
+    <div role="status" aria-label="記事一覧を読み込み中">
+      <span className="sr-only">記事一覧を読み込み中</span>
+      <SectionContainer>
+        <SectionHeader
+          label="Articles"
+          title="All Articles"
+          descriptionEn="Field notes from the trenches of developer productivity."
+          description="開発生産性の現場から得た知見。"
+        />
+        <div className="mb-8 grid gap-3 md:grid-cols-[1fr_auto]">
+          <Skeleton className="h-11 rounded-md border border-border bg-card" />
+          <div className="flex gap-2">
+            <Skeleton className="h-11 w-11 rounded-md border border-border bg-card" />
+            <Skeleton className="h-11 w-11 rounded-md border border-border bg-card" />
+          </div>
+        </div>
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5">
+          {Array.from({ length: 6 }, (_, index) => (
+            <CardSkeleton key={index} />
+          ))}
+        </div>
+      </SectionContainer>
+    </div>
+  );
+}
+
+export function ArticleDetailLoadingState() {
+  return (
+    <div role="status" aria-label="記事を読み込み中">
+      <span className="sr-only">記事を読み込み中</span>
+      <SectionContainer>
+        <div className="mx-auto max-w-[980px]">
+          <Skeleton className="mb-5 h-4 w-28" />
+          <Skeleton className="mb-3 h-10 w-full" />
+          <Skeleton className="mb-6 h-10 w-[72%]" />
+          <div className="mb-8 flex flex-wrap gap-2">
+            <Skeleton className="h-5 w-20 rounded border border-border" />
+            <Skeleton className="h-5 w-24 rounded border border-border" />
+          </div>
+          <Skeleton className="mb-10 aspect-[1200/630] w-full rounded-[11px] border border-border bg-card" />
+          <div className="grid gap-10 lg:grid-cols-[1fr_240px]">
+            <div className="space-y-4">
+              {Array.from({ length: 7 }, (_, index) => (
+                <Skeleton
+                  key={index}
+                  className={cn('h-4', index % 3 === 2 ? 'w-[76%]' : 'w-full')}
+                />
+              ))}
+            </div>
+            <div className="max-lg:hidden">
+              <Skeleton className="mb-3 h-4 w-20" />
+              <Skeleton className="mb-2 h-3 w-full" />
+              <Skeleton className="mb-2 h-3 w-[84%]" />
+              <Skeleton className="h-3 w-[68%]" />
+            </div>
+          </div>
+        </div>
+      </SectionContainer>
+    </div>
+  );
+}

--- a/src/lib/cms/adapters.test.ts
+++ b/src/lib/cms/adapters.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import { GaugeIcon, InfinityIcon, MonitorIcon } from 'lucide-react';
+
+import { adaptArticle, adaptTag } from './adapters';
+import type { CMSArticle, CMSTag } from './types';
+
+const cmsTag = {
+  id: 'tag_frontend',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  publishedAt: '2026-01-01T00:00:00.000Z',
+  revisedAt: '2026-01-01T00:00:00.000Z',
+  name: 'React',
+  category: ['frontend'],
+} satisfies CMSTag;
+
+describe('adaptTag', () => {
+  test('maps a CMS tag into the app tag shape', () => {
+    expect(adaptTag(cmsTag)).toEqual({
+      label: 'React',
+      category: 'frontend',
+      icon: MonitorIcon,
+    });
+  });
+
+  test('rejects a tag category that is not supported by the app', () => {
+    expect(() =>
+      adaptTag({
+        ...cmsTag,
+        id: 'tag_unknown',
+        category: ['unknown'],
+      }),
+    ).toThrow('Unsupported microCMS tag category "unknown" for tag "React"');
+  });
+
+  test('requires the planned category field on CMS tags', () => {
+    expect(() =>
+      adaptTag({
+        ...cmsTag,
+        category: [],
+      }),
+    ).toThrow('microCMS tag "React" is missing category');
+  });
+
+  test('rejects multiple categories because the app tag model expects one category', () => {
+    expect(() =>
+      adaptTag({
+        ...cmsTag,
+        category: ['frontend', 'tools'],
+      }),
+    ).toThrow('microCMS tag "React" must have exactly one category');
+  });
+});
+
+describe('adaptArticle', () => {
+  test('maps CMS article fields into the app article detail shape', () => {
+    const article = adaptArticle({
+      id: 'article_1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-04-02T00:00:00.000Z',
+      publishedAt: '2026-04-01T00:00:00.000Z',
+      revisedAt: '2026-04-02T00:00:00.000Z',
+      slug: 'dora-metrics',
+      title: 'DORA メトリクスを導入する',
+      excerpt: '開発チームの健全性を可視化する方法。',
+      content: '<p>DORA metrics improve delivery.</p>',
+      ogpImage: {
+        url: 'https://images.microcms-assets.io/assets/test/dora.png',
+        width: 1200,
+        height: 630,
+      },
+      tags: [
+        { ...cmsTag, id: 'tag_performance', name: 'Metrics', category: ['performance'] },
+        { ...cmsTag, id: 'tag_devops', name: 'DevOps', category: ['devops'] },
+      ],
+    } satisfies CMSArticle);
+
+    expect(article).toMatchObject({
+      slug: 'dora-metrics',
+      title: 'DORA メトリクスを導入する',
+      description: '開発チームの健全性を可視化する方法。',
+      excerpt: '開発チームの健全性を可視化する方法。',
+      content: '<p>DORA metrics improve delivery.</p>',
+      publishedAt: '2026-04-01',
+      updatedAt: '2026-04-02',
+      readingTime: '1 min',
+      thumbnailIcon: GaugeIcon,
+      thumbnailVariant: 'v1',
+      ogpImage: {
+        url: 'https://images.microcms-assets.io/assets/test/dora.png',
+        width: 1200,
+        height: 630,
+      },
+      tags: [
+        { label: 'Metrics', category: 'performance', icon: GaugeIcon },
+        { label: 'DevOps', category: 'devops', icon: InfinityIcon },
+      ],
+    });
+  });
+});

--- a/src/lib/cms/adapters.ts
+++ b/src/lib/cms/adapters.ts
@@ -1,0 +1,149 @@
+import {
+  CodeIcon,
+  FlaskConicalIcon,
+  GaugeIcon,
+  GitBranchIcon,
+  InfinityIcon,
+  MonitorIcon,
+  RocketIcon,
+  ServerIcon,
+  ShieldIcon,
+  SparklesIcon,
+  WrenchIcon,
+  type LucideIcon,
+} from 'lucide-react';
+
+import type { ArticleDetail } from '@/types/article';
+import type { Tag, TagCategory } from '@/types/tag';
+import { TAG_CATEGORY_COLORS } from '@/types/tag';
+
+import type { CMSArticle, CMSTag } from './types';
+
+const TAG_CATEGORY_ICONS = {
+  frontend: MonitorIcon,
+  backend: ServerIcon,
+  infra: GitBranchIcon,
+  devops: InfinityIcon,
+  languages: CodeIcon,
+  tools: WrenchIcon,
+  security: ShieldIcon,
+  performance: GaugeIcon,
+  testing: FlaskConicalIcon,
+  release: RocketIcon,
+} as const satisfies Record<TagCategory, LucideIcon>;
+
+const TAG_NAME_ICONS: Partial<Record<string, LucideIcon>> = {
+  devex: SparklesIcon,
+};
+
+const THUMBNAIL_VARIANTS = ['v1', 'v2', 'v3'] as const;
+const READING_CHARS_PER_MINUTE = 500;
+
+interface AdaptArticleOptions {
+  readonly index?: number;
+}
+
+export function adaptTag(tag: CMSTag): Tag {
+  const label = requireNonEmpty(tag.name, `microCMS tag "${tag.id}" is missing name`);
+  const category = requireTagCategory(tag.category, label);
+
+  return {
+    label,
+    category,
+    icon: TAG_NAME_ICONS[label.toLowerCase()] ?? TAG_CATEGORY_ICONS[category],
+  };
+}
+
+export function adaptArticle(
+  article: CMSArticle,
+  options: AdaptArticleOptions = {},
+): ArticleDetail {
+  const tags = article.tags.map(adaptTag);
+  const primaryTag = tags[0];
+
+  return {
+    slug: requireNonEmpty(article.slug, `microCMS article "${article.id}" is missing slug`),
+    title: requireNonEmpty(article.title, `microCMS article "${article.id}" is missing title`),
+    description: requireNonEmpty(
+      article.excerpt,
+      `microCMS article "${article.id}" is missing excerpt`,
+    ),
+    excerpt: article.excerpt,
+    content: requireNonEmpty(
+      article.content,
+      `microCMS article "${article.id}" is missing content`,
+    ),
+    ogpImage: {
+      url: requireNonEmpty(
+        article.ogpImage?.url,
+        `microCMS article "${article.id}" is missing ogpImage.url`,
+      ),
+      width: article.ogpImage.width,
+      height: article.ogpImage.height,
+    },
+    publishedAt: formatDate(article.publishedAt, article.id, 'publishedAt'),
+    updatedAt: formatDate(article.revisedAt ?? article.updatedAt, article.id, 'updatedAt'),
+    readingTime: calculateReadingTime(article.content),
+    thumbnailIcon: primaryTag?.icon ?? SparklesIcon,
+    thumbnailVariant: pickThumbnailVariant(options.index),
+    tags,
+  };
+}
+
+export function adaptArticles(articles: readonly CMSArticle[]): readonly ArticleDetail[] {
+  return articles.map((article, index) => adaptArticle(article, { index }));
+}
+
+function requireTagCategory(
+  category: TagCategory | string | readonly string[] | undefined,
+  label: string,
+): TagCategory {
+  if (Array.isArray(category) && category.length > 1) {
+    throw new Error(`microCMS tag "${label}" must have exactly one category`);
+  }
+
+  const normalized = Array.isArray(category) ? category[0] : category;
+
+  if (!normalized) {
+    throw new Error(`microCMS tag "${label}" is missing category`);
+  }
+
+  if (normalized in TAG_CATEGORY_COLORS) {
+    return normalized as TagCategory;
+  }
+
+  throw new Error(`Unsupported microCMS tag category "${normalized}" for tag "${label}"`);
+}
+
+function requireNonEmpty(value: string | undefined, message: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new Error(message);
+  }
+
+  return trimmed;
+}
+
+function formatDate(value: string, articleId: string, field: string): string {
+  if (Number.isNaN(Date.parse(value))) {
+    throw new Error(`microCMS article "${articleId}" has invalid ${field}`);
+  }
+
+  return value.slice(0, 10);
+}
+
+function calculateReadingTime(content: string): string {
+  const text = content
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&[a-z0-9#]+;/gi, ' ')
+    .replace(/\s+/g, '');
+  const minutes = Math.max(1, Math.ceil(text.length / READING_CHARS_PER_MINUTE));
+
+  return `${minutes} min`;
+}
+
+function pickThumbnailVariant(index: number | undefined): (typeof THUMBNAIL_VARIANTS)[number] {
+  if (typeof index !== 'number') return 'v1';
+
+  return THUMBNAIL_VARIANTS[index % THUMBNAIL_VARIANTS.length] ?? 'v1';
+}

--- a/src/lib/cms/articles.ts
+++ b/src/lib/cms/articles.ts
@@ -1,0 +1,87 @@
+import 'server-only';
+
+import { cacheLife } from 'next/cache';
+
+import type { ArticleDetail } from '@/types/article';
+import type { Tag } from '@/types/tag';
+
+import { adaptArticle, adaptArticles, adaptTag } from './adapters';
+import { getMicroCMSClient, getMicroCMSEndpoints, toMicroCMSFetchError } from './microcms';
+import type { CMSArticle, CMSTag } from './types';
+
+const CMS_CACHE_LIFE = {
+  stale: 300,
+  revalidate: 300,
+  expire: 3600,
+} as const;
+
+type CMSArticleContent = Omit<CMSArticle, 'id' | 'createdAt' | 'updatedAt' | 'revisedAt'>;
+type CMSTagContent = Omit<CMSTag, 'id' | 'createdAt' | 'updatedAt' | 'publishedAt' | 'revisedAt'>;
+
+export async function getArticles(): Promise<readonly ArticleDetail[]> {
+  'use cache';
+  cacheLife(CMS_CACHE_LIFE);
+
+  const endpoint = getMicroCMSEndpoints().articles;
+
+  try {
+    const articles = await getMicroCMSClient().getAllContents<CMSArticleContent>({
+      endpoint,
+      queries: {
+        depth: 1,
+        orders: '-publishedAt',
+      },
+    });
+
+    return adaptArticles(articles as readonly CMSArticle[]);
+  } catch (error) {
+    throw toMicroCMSFetchError(endpoint, 'fetch articles', error);
+  }
+}
+
+export async function getArticleBySlug(slug: string): Promise<ArticleDetail | null> {
+  'use cache';
+  cacheLife(CMS_CACHE_LIFE);
+
+  const endpoint = getMicroCMSEndpoints().articles;
+
+  try {
+    const response = await getMicroCMSClient().getList<CMSArticleContent>({
+      endpoint,
+      queries: {
+        depth: 1,
+        filters: `slug[equals]${slug}`,
+        limit: 2,
+      },
+    });
+
+    if (response.contents.length === 0) return null;
+    if (response.contents.length > 1) {
+      throw new Error(`microCMS returned duplicate articles for slug "${slug}"`);
+    }
+
+    return adaptArticle(response.contents[0]! as CMSArticle);
+  } catch (error) {
+    throw toMicroCMSFetchError(endpoint, `fetch article "${slug}"`, error);
+  }
+}
+
+export async function getTags(): Promise<readonly Tag[]> {
+  'use cache';
+  cacheLife(CMS_CACHE_LIFE);
+
+  const endpoint = getMicroCMSEndpoints().tags;
+
+  try {
+    const tags = await getMicroCMSClient().getAllContents<CMSTagContent>({
+      endpoint,
+      queries: {
+        orders: 'name',
+      },
+    });
+
+    return tags.map((tag) => adaptTag(tag as CMSTag));
+  } catch (error) {
+    throw toMicroCMSFetchError(endpoint, 'fetch tags', error);
+  }
+}

--- a/src/lib/cms/index.ts
+++ b/src/lib/cms/index.ts
@@ -1,0 +1,9 @@
+export { adaptArticle, adaptArticles, adaptTag } from './adapters';
+export { getArticleBySlug, getArticles, getTags } from './articles';
+export {
+  MicroCMSConfigurationError,
+  MicroCMSFetchError,
+  getMicroCMSClient,
+  getMicroCMSEndpoints,
+} from './microcms';
+export type { CMSArticle, CMSImage, CMSSystemFields, CMSTag } from './types';

--- a/src/lib/cms/microcms.ts
+++ b/src/lib/cms/microcms.ts
@@ -1,0 +1,70 @@
+import 'server-only';
+
+import { createClient } from 'microcms-js-sdk';
+
+const DEFAULT_ARTICLES_ENDPOINT = 'articles';
+const DEFAULT_TAGS_ENDPOINT = 'tags';
+
+type MicroCMSClient = ReturnType<typeof createClient>;
+
+let client: MicroCMSClient | undefined;
+
+export class MicroCMSConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MicroCMSConfigurationError';
+  }
+}
+
+export class MicroCMSFetchError extends Error {
+  constructor(
+    message: string,
+    options?: {
+      readonly cause?: unknown;
+    },
+  ) {
+    super(message, options);
+    this.name = 'MicroCMSFetchError';
+  }
+}
+
+export function getMicroCMSClient(): MicroCMSClient {
+  if (client) return client;
+
+  const serviceDomain = requireEnv('MICROCMS_SERVICE_DOMAIN');
+  const apiKey = requireEnv('MICROCMS_API_KEY');
+
+  client = createClient({
+    serviceDomain,
+    apiKey,
+    retry: true,
+  });
+
+  return client;
+}
+
+export function getMicroCMSEndpoints() {
+  return {
+    articles: process.env.MICROCMS_ARTICLES?.trim() || DEFAULT_ARTICLES_ENDPOINT,
+    tags: process.env.MICROCMS_TAGS?.trim() || DEFAULT_TAGS_ENDPOINT,
+  } as const;
+}
+
+export function toMicroCMSFetchError(endpoint: string, action: string, cause: unknown) {
+  if (cause instanceof MicroCMSConfigurationError || cause instanceof MicroCMSFetchError) {
+    return cause;
+  }
+
+  return new MicroCMSFetchError(`Failed to ${action} from microCMS endpoint "${endpoint}"`, {
+    cause,
+  });
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new MicroCMSConfigurationError(`${name} is required for microCMS server requests`);
+  }
+
+  return value;
+}

--- a/src/lib/cms/types.ts
+++ b/src/lib/cms/types.ts
@@ -1,0 +1,30 @@
+import type { TagCategory } from '@/types/tag';
+
+export interface CMSSystemFields {
+  readonly id: string;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+  readonly publishedAt?: string;
+  readonly revisedAt?: string;
+}
+
+export interface CMSImage {
+  readonly url: string;
+  readonly width?: number;
+  readonly height?: number;
+}
+
+export interface CMSTag extends CMSSystemFields {
+  readonly name: string;
+  readonly category?: TagCategory | string | readonly string[];
+}
+
+export interface CMSArticle extends CMSSystemFields {
+  readonly slug: string;
+  readonly title: string;
+  readonly publishedAt: string;
+  readonly content: string;
+  readonly excerpt: string;
+  readonly ogpImage: CMSImage;
+  readonly tags: readonly CMSTag[];
+}

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -1,6 +1,12 @@
 import type { LucideIcon } from 'lucide-react';
 import type { Tag } from './tag';
 
+export interface ArticleImage {
+  readonly url: string;
+  readonly width?: number;
+  readonly height?: number;
+}
+
 export interface Article {
   readonly slug: string;
   readonly title: string;
@@ -11,4 +17,10 @@ export interface Article {
   readonly thumbnailIcon: LucideIcon;
   readonly thumbnailVariant?: 'v1' | 'v2' | 'v3';
   readonly tags: readonly Tag[];
+}
+
+export interface ArticleDetail extends Article {
+  readonly excerpt: string;
+  readonly content: string;
+  readonly ogpImage: ArticleImage;
 }


### PR DESCRIPTION
## Summary
- Add server-only microCMS client helpers with cached article/tag fetch functions
- Add CMS schema types and adapters from microCMS payloads to app Article/Tag shapes
- Add adapter tests for tag category mapping, missing/unsupported/multiple categories, and article conversion
- Add App Router loading states for home/articles/article detail plus Storybook and v12 design mock coverage
- Add microcms-js-sdk and sanitize env example values

## microCMS checks
- tags endpoint now has 10 tags with one category value each
- articles endpoint has 11 articles
- article tag references resolve and include supported categories
- projects remain static/hardcoded

## Verification
- bun test src/lib/cms/adapters.test.ts
- bun run format:check
- bun run lint
- bun run typecheck
- bun run build (requires network access for Google Fonts in this sandbox)

Closes #28