### PR TITLE
[codex] Implement articles listing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.playwright-cli/
 
 # Coverage
 coverage/

--- a/src/app/articles/articles-cache.ts
+++ b/src/app/articles/articles-cache.ts
@@ -1,0 +1,57 @@
+import 'server-only';
+
+import { cacheLife } from 'next/cache';
+
+import { adaptArticles, adaptTag, getMicroCMSClient, getMicroCMSEndpoints } from '@/lib/cms';
+import { toMicroCMSFetchError } from '@/lib/cms/microcms';
+import type { CMSArticle, CMSTag } from '@/lib/cms/types';
+
+const ARTICLES_PAGE_CACHE_LIFE = {
+  stale: 300,
+  revalidate: 300,
+  expire: 3600,
+} as const;
+
+export async function getArticlesPageContent() {
+  const { articles, tags } = await getCachedArticlesPageContent();
+
+  return {
+    articles: adaptArticles(articles),
+    tags: tags.map(adaptTag),
+  };
+}
+
+type CMSArticleContent = Omit<CMSArticle, 'id' | 'createdAt' | 'updatedAt' | 'revisedAt'>;
+type CMSTagContent = Omit<CMSTag, 'id' | 'createdAt' | 'updatedAt' | 'publishedAt' | 'revisedAt'>;
+
+async function getCachedArticlesPageContent() {
+  'use cache';
+  cacheLife(ARTICLES_PAGE_CACHE_LIFE);
+
+  const endpoints = getMicroCMSEndpoints();
+
+  try {
+    const [articles, tags] = await Promise.all([
+      getMicroCMSClient().getAllContents<CMSArticleContent>({
+        endpoint: endpoints.articles,
+        queries: {
+          depth: 1,
+          orders: '-publishedAt',
+        },
+      }),
+      getMicroCMSClient().getAllContents<CMSTagContent>({
+        endpoint: endpoints.tags,
+        queries: {
+          orders: 'name',
+        },
+      }),
+    ]);
+
+    return {
+      articles: articles as readonly CMSArticle[],
+      tags: tags as readonly CMSTag[],
+    };
+  } catch (error) {
+    throw toMicroCMSFetchError(endpoints.articles, 'fetch article index content', error);
+  }
+}

--- a/src/app/articles/articles-query.test.ts
+++ b/src/app/articles/articles-query.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+
+import { buildArticlesHref, normalizeArticlesQuery } from './articles-query';
+
+describe('normalizeArticlesQuery', () => {
+  test('normalizes empty search params to the default article query', () => {
+    expect(normalizeArticlesQuery({})).toEqual({
+      q: '',
+      tag: '',
+      page: 1,
+      view: 'grid',
+    });
+  });
+
+  test('trims q and tag, accepts positive integer page, and keeps list view', () => {
+    expect(
+      normalizeArticlesQuery({
+        q: '  cache strategy  ',
+        tag: '  Performance ',
+        page: '3',
+        view: 'list',
+      }),
+    ).toEqual({
+      q: 'cache strategy',
+      tag: 'Performance',
+      page: 3,
+      view: 'list',
+    });
+  });
+
+  test('falls back for invalid page and view values', () => {
+    expect(
+      normalizeArticlesQuery({
+        page: '0',
+        view: 'cards',
+      }),
+    ).toEqual({
+      q: '',
+      tag: '',
+      page: 1,
+      view: 'grid',
+    });
+  });
+
+  test('uses the first value when a search param is repeated', () => {
+    expect(
+      normalizeArticlesQuery({
+        q: ['devex', 'ignored'],
+        tag: ['Tools', 'Performance'],
+        page: ['2', '9'],
+        view: ['list', 'grid'],
+      }),
+    ).toEqual({
+      q: 'devex',
+      tag: 'Tools',
+      page: 2,
+      view: 'list',
+    });
+  });
+});
+
+describe('buildArticlesHref', () => {
+  test('omits default values from the generated URL', () => {
+    expect(buildArticlesHref({ q: '', tag: '', page: 1, view: 'grid' })).toBe('/articles');
+  });
+
+  test('preserves active filters and view while changing page', () => {
+    expect(
+      buildArticlesHref({ q: 'cache', tag: 'Performance', page: 1, view: 'list' }, { page: 2 }),
+    ).toBe('/articles?q=cache&tag=Performance&page=2&view=list');
+  });
+
+  test('resets page to one when q, tag, or view changes', () => {
+    expect(
+      buildArticlesHref(
+        { q: 'cache', tag: 'Performance', page: 4, view: 'grid' },
+        { tag: 'DevOps' },
+      ),
+    ).toBe('/articles?q=cache&tag=DevOps');
+
+    expect(
+      buildArticlesHref(
+        { q: 'cache', tag: 'Performance', page: 4, view: 'grid' },
+        { view: 'list' },
+      ),
+    ).toBe('/articles?q=cache&tag=Performance&view=list');
+  });
+});

--- a/src/app/articles/articles-query.ts
+++ b/src/app/articles/articles-query.ts
@@ -1,0 +1,60 @@
+export type ArticlesView = 'grid' | 'list';
+
+export interface ArticlesQuery {
+  readonly q: string;
+  readonly tag: string;
+  readonly page: number;
+  readonly view: ArticlesView;
+}
+
+export type RawArticlesSearchParams = Record<string, string | readonly string[] | undefined>;
+
+const DEFAULT_ARTICLES_QUERY = {
+  q: '',
+  tag: '',
+  page: 1,
+  view: 'grid',
+} as const satisfies ArticlesQuery;
+
+const PAGE_PATTERN = /^[1-9]\d*$/;
+
+export function normalizeArticlesQuery(searchParams: RawArticlesSearchParams): ArticlesQuery {
+  const q = firstValue(searchParams.q).trim();
+  const tag = firstValue(searchParams.tag).trim();
+  const pageValue = firstValue(searchParams.page);
+  const viewValue = firstValue(searchParams.view);
+
+  return {
+    q,
+    tag,
+    page: PAGE_PATTERN.test(pageValue) ? Number(pageValue) : DEFAULT_ARTICLES_QUERY.page,
+    view: viewValue === 'list' ? 'list' : DEFAULT_ARTICLES_QUERY.view,
+  };
+}
+
+export function buildArticlesHref(query: ArticlesQuery, patch: Partial<ArticlesQuery> = {}) {
+  const nextQuery = normalizeArticlesQuery({
+    q: patch.q ?? query.q,
+    tag: patch.tag ?? query.tag,
+    page: String(patch.page ?? query.page),
+    view: patch.view ?? query.view,
+  });
+
+  const shouldResetPage =
+    patch.q !== undefined || patch.tag !== undefined || patch.view !== undefined;
+  const page = shouldResetPage ? DEFAULT_ARTICLES_QUERY.page : nextQuery.page;
+  const params = new URLSearchParams();
+
+  if (nextQuery.q) params.set('q', nextQuery.q);
+  if (nextQuery.tag) params.set('tag', nextQuery.tag);
+  if (page !== DEFAULT_ARTICLES_QUERY.page) params.set('page', String(page));
+  if (nextQuery.view !== DEFAULT_ARTICLES_QUERY.view) params.set('view', nextQuery.view);
+
+  const queryString = params.toString();
+  return queryString ? `/articles?${queryString}` : '/articles';
+}
+
+function firstValue(value: string | readonly string[] | undefined): string {
+  if (typeof value === 'string') return value;
+  return value?.[0] ?? '';
+}

--- a/src/app/articles/page.tsx
+++ b/src/app/articles/page.tsx
@@ -1,0 +1,368 @@
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  LayersIcon,
+  LayoutGridIcon,
+  ListIcon,
+} from 'lucide-react';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+import { ArticleCard } from '@/components/article-card';
+import { ListCard } from '@/components/list-card';
+import { ScrollRevealList } from '@/components/scroll-reveal-list';
+import { SectionContainer, SectionHeader } from '@/components/section';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { ArticleDetail } from '@/types/article';
+import type { Tag } from '@/types/tag';
+import { TAG_CATEGORY_COLORS } from '@/types/tag';
+
+import { getArticlesPageContent } from './articles-cache';
+import {
+  buildArticlesHref,
+  normalizeArticlesQuery,
+  type ArticlesQuery,
+  type ArticlesView,
+  type RawArticlesSearchParams,
+} from './articles-query';
+import { SearchForm } from './search-form';
+
+export const metadata: Metadata = {
+  title: 'Articles | Rymlab',
+  description: '生産性・自動化・エンジニアリングの最前線から。',
+};
+
+const ARTICLES_PER_PAGE = 6;
+
+interface ArticlesPageProps {
+  readonly searchParams?: Promise<RawArticlesSearchParams>;
+}
+
+export default async function ArticlesPage({ searchParams }: ArticlesPageProps) {
+  const query = normalizeArticlesQuery((await searchParams) ?? {});
+  const { articles, tags } = await getArticlesPageContent();
+  const filteredArticles = filterArticles(articles, query);
+  const totalPages = Math.max(1, Math.ceil(filteredArticles.length / ARTICLES_PER_PAGE));
+  const currentPage = Math.min(query.page, totalPages);
+  const currentQuery = { ...query, page: currentPage };
+  const pageArticles = paginateArticles(filteredArticles, currentPage);
+  const rangeStart = filteredArticles.length === 0 ? 0 : (currentPage - 1) * ARTICLES_PER_PAGE + 1;
+  const rangeEnd = Math.min(currentPage * ARTICLES_PER_PAGE, filteredArticles.length);
+
+  return (
+    <SectionContainer>
+      <SectionHeader
+        label="Articles"
+        title="All Articles"
+        descriptionEn="Insights on developer productivity, automation, and modern engineering."
+        description="生産性・自動化・エンジニアリングの最前線から。"
+      />
+
+      <div className="mb-7 flex flex-col gap-3">
+        <div className="flex flex-wrap items-center gap-2.5">
+          <SearchForm query={currentQuery} />
+          <ViewToggle query={currentQuery} />
+        </div>
+        <TagFilter tags={tags} query={currentQuery} />
+      </div>
+
+      {pageArticles.length > 0 ? (
+        <ArticlesList articles={pageArticles} view={query.view} />
+      ) : (
+        <EmptyArticlesState query={currentQuery} />
+      )}
+
+      <Pagination
+        query={currentQuery}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        totalItems={filteredArticles.length}
+        rangeStart={rangeStart}
+        rangeEnd={rangeEnd}
+      />
+    </SectionContainer>
+  );
+}
+
+function ArticlesList({
+  articles,
+  view,
+}: {
+  readonly articles: readonly ArticleDetail[];
+  readonly view: ArticlesView;
+}) {
+  if (view === 'list') {
+    return (
+      <ScrollRevealList className="grid gap-3">
+        {articles.map((article) => (
+          <ListCard key={article.slug} article={article} />
+        ))}
+      </ScrollRevealList>
+    );
+  }
+
+  return (
+    <ScrollRevealList className="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-5 max-md:grid-cols-[repeat(auto-fill,minmax(min(280px,100%),1fr))]">
+      {articles.map((article) => (
+        <ArticleCard key={article.slug} article={article} />
+      ))}
+    </ScrollRevealList>
+  );
+}
+
+function ViewToggle({ query }: { readonly query: ArticlesQuery }) {
+  return (
+    <div className="ml-auto flex gap-1" aria-label="Article view">
+      <Button
+        asChild
+        variant="outline"
+        size="icon"
+        className={cn(
+          'size-[34px] rounded-md bg-transparent text-muted-foreground shadow-none hover:border-primary hover:text-primary',
+          query.view === 'grid' &&
+            'border-[var(--tag-border)] bg-[var(--tag-bg)] text-[var(--tag-text)]',
+        )}
+      >
+        <Link href={buildArticlesHref(query, { view: 'grid' })} aria-label="Grid view">
+          <LayoutGridIcon aria-hidden="true" />
+        </Link>
+      </Button>
+      <Button
+        asChild
+        variant="outline"
+        size="icon"
+        className={cn(
+          'size-[34px] rounded-md bg-transparent text-muted-foreground shadow-none hover:border-primary hover:text-primary',
+          query.view === 'list' &&
+            'border-[var(--tag-border)] bg-[var(--tag-bg)] text-[var(--tag-text)]',
+        )}
+      >
+        <Link href={buildArticlesHref(query, { view: 'list' })} aria-label="List view">
+          <ListIcon aria-hidden="true" />
+        </Link>
+      </Button>
+    </div>
+  );
+}
+
+function TagFilter({
+  tags,
+  query,
+}: {
+  readonly tags: readonly Tag[];
+  readonly query: ArticlesQuery;
+}) {
+  return (
+    <div
+      className="flex gap-1.5 overflow-x-auto pb-1 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden md:flex-wrap md:overflow-visible md:pb-0"
+      aria-label="Filter articles by tag"
+    >
+      <FilterTagLink href={buildArticlesHref(query, { tag: '' })} active={!query.tag}>
+        <LayersIcon aria-hidden="true" className="size-[13px]" />
+        All
+      </FilterTagLink>
+      {tags.map((tag) => {
+        const Icon = tag.icon;
+
+        return (
+          <FilterTagLink
+            key={`${tag.category}-${tag.label}`}
+            href={buildArticlesHref(query, { tag: tag.label })}
+            active={query.tag === tag.label}
+          >
+            {Icon && (
+              <Icon
+                aria-hidden="true"
+                className="size-[13px]"
+                style={{ color: TAG_CATEGORY_COLORS[tag.category] }}
+              />
+            )}
+            {tag.label}
+          </FilterTagLink>
+        );
+      })}
+    </div>
+  );
+}
+
+function FilterTagLink({
+  href,
+  active,
+  children,
+}: {
+  readonly href: string;
+  readonly active: boolean;
+  readonly children: React.ReactNode;
+}) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'inline-flex h-8 shrink-0 items-center gap-1.5 rounded-[7px] border border-border px-3.5 text-[12.5px] text-text-secondary transition-colors',
+        'hover:border-primary hover:text-primary',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+        active && 'border-[var(--tag-border)] bg-[var(--tag-bg)] text-[var(--tag-text)]',
+      )}
+      aria-current={active ? 'true' : undefined}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function Pagination({
+  query,
+  currentPage,
+  totalPages,
+  totalItems,
+  rangeStart,
+  rangeEnd,
+}: {
+  readonly query: ArticlesQuery;
+  readonly currentPage: number;
+  readonly totalPages: number;
+  readonly totalItems: number;
+  readonly rangeStart: number;
+  readonly rangeEnd: number;
+}) {
+  const pages = getVisiblePages(currentPage, totalPages);
+
+  return (
+    <nav
+      className="mt-10 flex flex-wrap items-center justify-center gap-1.5"
+      aria-label="Articles pagination"
+    >
+      <PaginationLink
+        href={buildArticlesHref(query, { page: Math.max(1, currentPage - 1) })}
+        disabled={currentPage === 1 || totalItems === 0}
+        ariaLabel="Previous page"
+      >
+        <ChevronLeftIcon aria-hidden="true" className="size-3.5" />
+      </PaginationLink>
+
+      {pages.map((page) => (
+        <PaginationLink
+          key={page}
+          href={buildArticlesHref(query, { page })}
+          active={page === currentPage}
+          ariaLabel={`Page ${page}`}
+        >
+          {page}
+        </PaginationLink>
+      ))}
+
+      <PaginationLink
+        href={buildArticlesHref(query, { page: Math.min(totalPages, currentPage + 1) })}
+        disabled={currentPage === totalPages || totalItems === 0}
+        ariaLabel="Next page"
+      >
+        <ChevronRightIcon aria-hidden="true" className="size-3.5" />
+      </PaginationLink>
+
+      <span className="mx-2 font-mono text-xs text-muted-foreground">
+        {rangeStart}-{rangeEnd} / {totalItems} articles
+      </span>
+    </nav>
+  );
+}
+
+function PaginationLink({
+  href,
+  active = false,
+  disabled = false,
+  ariaLabel,
+  children,
+}: {
+  readonly href: string;
+  readonly active?: boolean;
+  readonly disabled?: boolean;
+  readonly ariaLabel: string;
+  readonly children: React.ReactNode;
+}) {
+  const className = cn(
+    'flex size-9 items-center justify-center rounded-[7px] border border-border text-[13px] text-text-secondary transition-colors',
+    'hover:border-primary hover:text-primary',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+    active && 'border-transparent bg-[image:var(--accent-gradient)] text-white hover:text-white',
+    disabled && 'pointer-events-none opacity-45',
+  );
+
+  if (disabled) {
+    return (
+      <span className={className} aria-label={ariaLabel} aria-disabled="true">
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className={className}
+      aria-label={ariaLabel}
+      aria-current={active ? 'page' : undefined}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function EmptyArticlesState({ query }: { readonly query: ArticlesQuery }) {
+  const hasFilters = Boolean(query.q || query.tag);
+
+  return (
+    <div className="rounded-[11px] border border-border bg-card px-5 py-12 text-center">
+      <h3 className="mb-2 text-base font-semibold">No articles found</h3>
+      <p className="mx-auto max-w-[460px] text-sm leading-6 text-text-secondary">
+        {hasFilters
+          ? '検索条件に一致する記事はありません。キーワードやタグを変更してください。'
+          : '記事はまだ公開されていません。'}
+      </p>
+      {hasFilters && (
+        <Button asChild variant="outline" size="sm" className="mt-5">
+          <Link href={buildArticlesHref(query, { q: '', tag: '' })}>Clear filters</Link>
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function filterArticles(articles: readonly ArticleDetail[], query: ArticlesQuery) {
+  const normalizedQuery = normalizeSearchValue(query.q);
+  const normalizedTag = normalizeSearchValue(query.tag);
+
+  return articles.filter((article) => {
+    const matchesTag =
+      !normalizedTag ||
+      article.tags.some((tag) => normalizeSearchValue(tag.label) === normalizedTag);
+
+    if (!matchesTag) return false;
+    if (!normalizedQuery) return true;
+
+    const searchableText = [
+      article.title,
+      article.description,
+      article.excerpt,
+      ...article.tags.map((tag) => tag.label),
+    ].join(' ');
+
+    return normalizeSearchValue(searchableText).includes(normalizedQuery);
+  });
+}
+
+function paginateArticles(articles: readonly ArticleDetail[], page: number) {
+  const startIndex = (page - 1) * ARTICLES_PER_PAGE;
+  return articles.slice(startIndex, startIndex + ARTICLES_PER_PAGE);
+}
+
+function getVisiblePages(currentPage: number, totalPages: number) {
+  const start = Math.max(1, Math.min(currentPage - 2, totalPages - 4));
+  const end = Math.min(totalPages, start + 4);
+
+  return Array.from({ length: end - start + 1 }, (_, index) => start + index);
+}
+
+function normalizeSearchValue(value: string | undefined) {
+  return value?.trim().toLowerCase() ?? '';
+}

--- a/src/app/articles/search-form.tsx
+++ b/src/app/articles/search-form.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { SearchIcon, XIcon } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { startTransition, useRef } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+import { buildArticlesHref, type ArticlesQuery } from './articles-query';
+
+interface SearchFormProps {
+  readonly query: ArticlesQuery;
+}
+
+export function SearchForm({ query }: SearchFormProps) {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <form
+      role="search"
+      className="relative min-w-[min(100%,260px)] flex-1"
+      onSubmit={(event) => {
+        event.preventDefault();
+        const formData = new FormData(event.currentTarget);
+        const q = String(formData.get('q') ?? '');
+
+        startTransition(() => {
+          router.push(buildArticlesHref(query, { q }));
+        });
+      }}
+    >
+      <SearchIcon
+        aria-hidden="true"
+        className="pointer-events-none absolute left-3.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
+      />
+      <Input
+        ref={inputRef}
+        name="q"
+        type="search"
+        defaultValue={query.q}
+        aria-label="Search articles"
+        placeholder="Search articles..."
+        className="h-11 rounded-[7px] bg-card pl-9 pr-10 text-[13px] shadow-none"
+      />
+      {query.q && (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          aria-label="Clear search"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-primary"
+          onClick={() => {
+            if (inputRef.current) inputRef.current.value = '';
+            startTransition(() => {
+              router.push(buildArticlesHref(query, { q: '' }));
+            });
+          }}
+        >
+          <XIcon aria-hidden="true" />
+        </Button>
+      )}
+    </form>
+  );
+}

--- a/src/lib/cms/adapters.test.ts
+++ b/src/lib/cms/adapters.test.ts
@@ -97,4 +97,31 @@ describe('adaptArticle', () => {
       ],
     });
   });
+
+  test('maps CMS article rich content body into the app article detail content', () => {
+    const article = adaptArticle({
+      id: 'article_rich_content',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-04-02T00:00:00.000Z',
+      publishedAt: '2026-04-01T00:00:00.000Z',
+      revisedAt: '2026-04-02T00:00:00.000Z',
+      slug: 'rich-content',
+      title: 'Rich content',
+      excerpt: 'CMS rich content body.',
+      content: {
+        fieldId: 'richEditor',
+        showToc: true,
+        body: '<p>Rich body</p>',
+      },
+      ogpImage: {
+        url: 'https://images.microcms-assets.io/assets/test/rich.png',
+        width: 1200,
+        height: 630,
+      },
+      tags: [cmsTag],
+    } satisfies CMSArticle);
+
+    expect(article.content).toBe('<p>Rich body</p>');
+    expect(article.readingTime).toBe('1 min');
+  });
 });

--- a/src/lib/cms/adapters.ts
+++ b/src/lib/cms/adapters.ts
@@ -60,6 +60,7 @@ export function adaptArticle(
 ): ArticleDetail {
   const tags = article.tags.map(adaptTag);
   const primaryTag = tags[0];
+  const content = extractArticleContent(article);
 
   return {
     slug: requireNonEmpty(article.slug, `microCMS article "${article.id}" is missing slug`),
@@ -69,10 +70,7 @@ export function adaptArticle(
       `microCMS article "${article.id}" is missing excerpt`,
     ),
     excerpt: article.excerpt,
-    content: requireNonEmpty(
-      article.content,
-      `microCMS article "${article.id}" is missing content`,
-    ),
+    content,
     ogpImage: {
       url: requireNonEmpty(
         article.ogpImage?.url,
@@ -83,7 +81,7 @@ export function adaptArticle(
     },
     publishedAt: formatDate(article.publishedAt, article.id, 'publishedAt'),
     updatedAt: formatDate(article.revisedAt ?? article.updatedAt, article.id, 'updatedAt'),
-    readingTime: calculateReadingTime(article.content),
+    readingTime: calculateReadingTime(content),
     thumbnailIcon: primaryTag?.icon ?? SparklesIcon,
     thumbnailVariant: pickThumbnailVariant(options.index),
     tags,
@@ -122,6 +120,16 @@ function requireNonEmpty(value: string | undefined, message: string): string {
   }
 
   return trimmed;
+}
+
+function extractArticleContent(article: CMSArticle): string {
+  const content = article.content;
+
+  if (typeof content === 'string') {
+    return requireNonEmpty(content, `microCMS article "${article.id}" is missing content`);
+  }
+
+  return requireNonEmpty(content?.body, `microCMS article "${article.id}" is missing content.body`);
 }
 
 function formatDate(value: string, articleId: string, field: string): string {

--- a/src/lib/cms/types.ts
+++ b/src/lib/cms/types.ts
@@ -14,6 +14,13 @@ export interface CMSImage {
   readonly height?: number;
 }
 
+export interface CMSArticleContent {
+  readonly fieldId?: string;
+  readonly showToc?: boolean;
+  readonly body?: string;
+  readonly relatedArticles?: readonly CMSArticle[];
+}
+
 export interface CMSTag extends CMSSystemFields {
   readonly name: string;
   readonly category?: TagCategory | string | readonly string[];
@@ -23,7 +30,7 @@ export interface CMSArticle extends CMSSystemFields {
   readonly slug: string;
   readonly title: string;
   readonly publishedAt: string;
-  readonly content: string;
+  readonly content: string | CMSArticleContent;
   readonly excerpt: string;
   readonly ogpImage: CMSImage;
   readonly tags: readonly CMSTag[];


### PR DESCRIPTION
## Summary

- Implement `/articles` with CMS-backed article listing, search, tag filters, pagination, and grid/list view switching driven by URL search params.
- Add `articles-query.ts` for query normalization and URL generation, plus focused unit coverage.
- Add a server-only `'use cache'` wrapper for the article index CMS fetch path.
- Update the CMS article adapter to support the current rich content object shape (`content.body`) without exposing API keys or CMS internals to client components.
- Ignore local Playwright CLI verification artifacts.

## Validation

- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun test src/app/articles/articles-query.test.ts src/lib/cms/adapters.test.ts`
- `bun run build` with local main `.env.local` and network access for Google Fonts / microCMS

## Browser Verification

- Confirmed `/articles` renders 11 CMS articles with pagination.
- Confirmed grid/list view switching preserves URL params.
- Confirmed search updates `q` and filters results.
- Confirmed tag filtering and empty-result state.
- Confirmed mobile tag filter is horizontally scrollable.

Note: the `browser-use` CLI was installed after the initial verification and was not visible to the existing Codex session PATH at first, so browser interaction was completed with Playwright CLI as a fallback.