### PR TITLE
[codex] Make production CSP report-only

### DIFF
--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -31,7 +31,7 @@ describe('buildContentSecurityPolicy', () => {
 });
 
 describe('getSecurityHeaders', () => {
-  test('uses report-only CSP outside production and HSTS only in production', () => {
+  test('uses report-only CSP in all environments while production rendering is investigated', () => {
     const developmentHeaders = getSecurityHeaders({ isProduction: false });
     const productionHeaders = getSecurityHeaders({ isProduction: true });
 
@@ -44,7 +44,12 @@ describe('getSecurityHeaders', () => {
     expect(developmentHeaders.some((header) => header.key === 'Strict-Transport-Security')).toBe(
       false,
     );
-    expect(productionHeaders.some((header) => header.key === 'Content-Security-Policy')).toBe(true);
+    expect(productionHeaders.some((header) => header.key === 'Content-Security-Policy')).toBe(
+      false,
+    );
+    expect(
+      productionHeaders.some((header) => header.key === 'Content-Security-Policy-Report-Only'),
+    ).toBe(true);
     expect(productionHeaders.some((header) => header.key === 'Strict-Transport-Security')).toBe(
       true,
     );

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -56,7 +56,7 @@ export function getSecurityHeaders({ isProduction }: GetSecurityHeadersOptions):
       value: 'camera=(), microphone=(), geolocation=(), payment=(), usb=()',
     },
     {
-      key: isProduction ? 'Content-Security-Policy' : 'Content-Security-Policy-Report-Only',
+      key: 'Content-Security-Policy-Report-Only',
       value: buildContentSecurityPolicy({ reportOnly: !isProduction }),
     },
     ...(isProduction

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -26,12 +26,12 @@ export function proxy(request: NextRequest) {
     reportOnly: false,
   });
 
-  // Production CSP must be dynamic so each request receives a fresh nonce.
-  // The request-header override lets Next.js attach that nonce to runtime inline scripts.
+  // Production CSP stays dynamic so each request receives a fresh nonce, but it is
+  // report-only while Vercel rendering is being diagnosed.
   markDefaultLocaleRewrite(response);
   setRequestHeaderOverride(response, 'x-nonce', nonce);
-  setRequestHeaderOverride(response, 'content-security-policy', contentSecurityPolicy);
-  response.headers.set('Content-Security-Policy', contentSecurityPolicy);
+  setRequestHeaderOverride(response, 'content-security-policy-report-only', contentSecurityPolicy);
+  response.headers.set('Content-Security-Policy-Report-Only', contentSecurityPolicy);
 
   return response;
 }


### PR DESCRIPTION
## Summary

- Switch production CSP responses from enforced `Content-Security-Policy` to `Content-Security-Policy-Report-Only` for Vercel rendering diagnosis.
- Keep the dynamic nonce-bearing policy content in `proxy.ts`, but report violations instead of blocking browser execution.
- Update CSP header tests so production Report-Only behavior is explicit.

## Why

The Vercel deployment builds successfully, but browser rendering can be blocked by enforced CSP when Next.js inline runtime/RSC streaming scripts are emitted without matching nonces. This change is intended as a temporary diagnostic/recovery step: collect CSP reports while removing the browser-side block.

## Verification

- `bun test src/lib/security/csp.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build` with network access for Google Fonts
- Local production smoke: `next start`, `curl` confirmed `content-security-policy-report-only` and no enforced `content-security-policy`
- Playwright smoke confirmed `/` renders hero content with `blockedMessages: 0` and Report-Only CSP present

## Follow-up

After Vercel rendering is confirmed, replace this temporary Report-Only posture with a strict CSP strategy that is compatible with Next.js PPR/streaming output.