### PR TITLE
[codex] Disable experimental SRI on top of report-only CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,12 +12,6 @@ const nextConfig: NextConfig = {
   // Enable 'use cache' directive for server component and function caching
   cacheComponents: true,
 
-  experimental: {
-    sri: {
-      algorithm: 'sha256',
-    },
-  },
-
   images: {
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [


### PR DESCRIPTION
## Summary

- Disable Next.js `experimental.sri` by removing the `sri` configuration from `next.config.ts`.
- Stack this on top of #87 because preview verification showed SRI-only is not sufficient; CSP Report-Only is also required for the content to render.

## Diagnosis

The rendering failure has two separate blockers:

1. CSP enforcement blocks Next/React inline runtime scripts. #87 changes production CSP to `Content-Security-Policy-Report-Only` while the CSP policy is investigated.
2. Browser Subresource Integrity blocks a Turbopack chunk when `experimental.sri` is enabled. This PR disables SRI generation.

The main-based SRI-only preview did not fix the page. The combined preview with #87 + this PR did render the missing microCMS content and static cards.

## Verification

- `node -e "...experimental.sri is disabled..."`
- `bun test src/lib/security/csp.test.ts`
- `bun run format:check`
- `bun run lint`
- `bun run typecheck`
- `bun run build`
- Production smoke on `http://localhost:3013/` and `/articles`
- Confirmed response header uses `content-security-policy-report-only`
- Confirmed served HTML has `integrity=0` for `/` and `/articles`
- Confirmed Playwright console check has `sriMessages=0` and `blockedMessages=0`

Depends on #87.